### PR TITLE
Add eye spy tours to front end

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8289,6 +8289,67 @@
 			"integrity": "sha512-P+M65QY2JQ5Y0G9KKdlDpo0zK+/OHptU5AaBwUfAIDJZk1MYf32Frm84EcOytfJE0t5JvkAnKlmjsXDnWzCJmQ==",
 			"dev": true
 		},
+		"html-dom-parser": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-1.0.2.tgz",
+			"integrity": "sha512-Jq4oVkVSn+10ut3fyc2P/Fs1jqTo0l45cP6Q8d2ef/9jfkYwulO0QXmyLI0VUiZrXF4czpGgMEJRa52CQ6Fk8Q==",
+			"dev": true,
+			"requires": {
+				"domhandler": "4.2.2",
+				"htmlparser2": "6.1.0"
+			},
+			"dependencies": {
+				"dom-serializer": {
+					"version": "1.3.2",
+					"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
+					"integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
+					"dev": true,
+					"requires": {
+						"domelementtype": "^2.0.1",
+						"domhandler": "^4.2.0",
+						"entities": "^2.0.0"
+					}
+				},
+				"domelementtype": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+					"integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
+					"dev": true
+				},
+				"domhandler": {
+					"version": "4.2.2",
+					"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.2.tgz",
+					"integrity": "sha512-PzE9aBMsdZO8TK4BnuJwH0QT41wgMbRzuZrHUcpYncEjmQazq8QEaBWgLG7ZyC/DAZKEgglpIA6j4Qn/HmxS3w==",
+					"dev": true,
+					"requires": {
+						"domelementtype": "^2.2.0"
+					}
+				},
+				"domutils": {
+					"version": "2.8.0",
+					"resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+					"integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+					"dev": true,
+					"requires": {
+						"dom-serializer": "^1.0.1",
+						"domelementtype": "^2.2.0",
+						"domhandler": "^4.2.0"
+					}
+				},
+				"htmlparser2": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
+					"integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
+					"dev": true,
+					"requires": {
+						"domelementtype": "^2.0.1",
+						"domhandler": "^4.0.0",
+						"domutils": "^2.5.2",
+						"entities": "^2.0.0"
+					}
+				}
+			}
+		},
 		"html-encoding-sniffer": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
@@ -8394,6 +8455,35 @@
 					"resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
 					"integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
 					"dev": true
+				}
+			}
+		},
+		"html-react-parser": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-1.4.0.tgz",
+			"integrity": "sha512-v8Kxy+7L90ZFSM690oJWBNRzZWZOQquYPpQt6kDQPzQyZptXgOJ69kHSi7xdqNdm1mOfsDPwF4K9Bo/dS5gRTQ==",
+			"dev": true,
+			"requires": {
+				"domhandler": "4.2.2",
+				"html-dom-parser": "1.0.2",
+				"react-property": "2.0.0",
+				"style-to-js": "1.1.0"
+			},
+			"dependencies": {
+				"domelementtype": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+					"integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
+					"dev": true
+				},
+				"domhandler": {
+					"version": "4.2.2",
+					"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.2.tgz",
+					"integrity": "sha512-PzE9aBMsdZO8TK4BnuJwH0QT41wgMbRzuZrHUcpYncEjmQazq8QEaBWgLG7ZyC/DAZKEgglpIA6j4Qn/HmxS3w==",
+					"dev": true,
+					"requires": {
+						"domelementtype": "^2.2.0"
+					}
 				}
 			}
 		},
@@ -8703,6 +8793,12 @@
 			"version": "1.3.8",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
 			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+			"dev": true
+		},
+		"inline-style-parser": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
+			"integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==",
 			"dev": true
 		},
 		"internal-ip": {
@@ -14701,6 +14797,12 @@
 				"prop-types": "^15.5.8"
 			}
 		},
+		"react-property": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.0.tgz",
+			"integrity": "sha512-kzmNjIgU32mO4mmH5+iUyrqlpFQhF8K2k7eZ4fdLSOPFrD1XgEuSBv9LDEgxRXTMBqMd8ppT0x6TIzqE5pdGdw==",
+			"dev": true
+		},
 		"react-redux": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.1.2.tgz",
@@ -17461,6 +17563,24 @@
 			"requires": {
 				"loader-utils": "^1.1.0",
 				"schema-utils": "^1.0.0"
+			}
+		},
+		"style-to-js": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.0.tgz",
+			"integrity": "sha512-1OqefPDxGrlMwcbfpsTVRyzwdhr4W0uxYQzeA2F1CBc8WG04udg2+ybRnvh3XYL4TdHQrCahLtax2jc8xaE6rA==",
+			"dev": true,
+			"requires": {
+				"style-to-object": "0.3.0"
+			}
+		},
+		"style-to-object": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.3.0.tgz",
+			"integrity": "sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==",
+			"dev": true,
+			"requires": {
+				"inline-style-parser": "0.1.1"
 			}
 		},
 		"stylehacks": {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
 		"flickity": "^2.0.10",
 		"gulp": "^4.0.2",
 		"gulp-zip": "^5.0.0",
+		"html-react-parser": "^1.4.0",
 		"node-sass-chokidar": "1.3.5",
 		"nodemon": "^2.0.2",
 		"normalize.css": "^7.0.0",

--- a/server/constants/tours/eyeSpy/dec-2021.json
+++ b/server/constants/tours/eyeSpy/dec-2021.json
@@ -1,0 +1,72 @@
+{
+    "title": "December 2021",
+    "subtitle": "",
+    "heroImageId": 6315,
+    "description": "Can you find these special seasonal-themed pieces in our galleries?",
+    "body": {
+        "from": 0,
+        "size": 25,
+        "_source": [
+            "id",
+            "title",
+            "people",
+            "medium",
+            "imageOriginalSecret",
+            "imageSecret",
+            "ensembleIndex",
+            "objRightsTypeId",
+            "onview",
+            "invno",
+            "image",
+            "curatorialApproval",
+            "shortDescription",
+            "nationality",
+            "birthDate",
+            "deathDate",
+            "artistPrefix",
+            "artistSuffix",
+            "culture",
+            "displayDate",
+            "medium",
+            "dimensions",
+            "creditLine",
+            "longDescription",
+            "bibliography",
+            "exhHistory",
+            "publishedProvenance"
+        ],
+        "query": {
+            "bool": {
+                "filter": {
+                    "terms": {
+                        "invno": [
+                            "bf177",
+                            "01.13.37",
+                            "bf575",
+                            "bf804",
+                            "01.04.55",
+                            "bf115",
+                            "bf2084",
+                            "a48",
+                            "a103",
+                            "a147"
+                        ]
+                    }
+                }
+            }
+        }
+    },
+    "customRoomOrder": [],
+    "clues": {
+        "BF177": "Find the lady with the hat at the show<br />and you'll find a lady in the know",
+        "01.13.37": "This face is made of painted stone<br />but because it is old, not many details are known",
+        "BF575": "We see a face without its features<br />though the lines can act as great teachers.",
+        "BF804": "This creature's face is ferocious and grumpy; its surroundings are rocky and bumpy.",
+        "01.04.55": "We think this face is made out of jadeite - before you go through the door, turn to the right!",
+        "BF115": "This face is painted completely in blue; he looks kind of sad - do you think this is true?",
+        "BF2084": "This face is playing hide and go seek; through the bare branches, he takes a peak!",
+        "A48": "This Egyptian God is making a silly face. You can see he's carved from a Limestone base.",
+        "A103": "This vase looks both to the left and the right; have you seen a more fascinating sight?",
+        "A147": "This face is surrounded by friends; her pony-tail has a leather band at the end."
+    }
+}

--- a/server/constants/tours/eyeSpy/index.js
+++ b/server/constants/tours/eyeSpy/index.js
@@ -1,7 +1,9 @@
 const test = require("./test.json");
+const dec2021 = require("./dec-2021.json")
 
 // Key is the slug/tourId of the tour
 module.exports = {
+    "dec-2021": dec2021,
     // Tour for test suite
     test,
 }

--- a/src/components/EyeSpyPage/EyeSpyPage.jsx
+++ b/src/components/EyeSpyPage/EyeSpyPage.jsx
@@ -11,6 +11,7 @@ import {
   DEFAULT_ROOM_ORDER,
 } from "../../constants";
 import { parseObject } from "../../objectDataUtils";
+import { formatTourData } from "../TourPage/tourPageHelper";
 
 export default class EyeSpyPage extends React.Component {
   constructor(props) {
@@ -45,15 +46,15 @@ export default class EyeSpyPage extends React.Component {
         const heroImageId = tourData.heroImageId;
         const object = objects.find((obj) => parseInt(obj._id) === heroImageId);
         const parsedObject = parseObject(object._source);
+        const sections = formatTourData(roomOrder, objects)
 
         this.setState({
           title: tourData.title,
           subtitle: tourData.subtitle,
           description: tourData.description,
-          objects: objects,
-          roomOrder: roomOrder,
           heroImageSrc: parsedObject.imageUrlLarge,
           metaImgUrl: parsedObject.imageUrlSmall,
+          sections: sections,
         });
       } catch (error) {
         console.log(
@@ -86,9 +87,8 @@ export default class EyeSpyPage extends React.Component {
       title,
       subtitle,
       description,
-      roomOrder,
-      objects,
       heroImageSrc,
+      sections
     } = this.state;
 
     return (
@@ -96,7 +96,7 @@ export default class EyeSpyPage extends React.Component {
         <SiteHtmlHelmetHead metaTags={this.getMetaTags(title)} />
         <HtmlClassManager />
         <SiteHeader isTour />
-        {tourId && title && objects ? (
+        {tourId && title && sections ? (
           // Display the tour if it was located
           <div>
             <StickyList
@@ -104,8 +104,7 @@ export default class EyeSpyPage extends React.Component {
               subtitle={subtitle}
               heroImageSrc={heroImageSrc}
               description={description}
-              objects={objects}
-              sectionOrder={roomOrder}
+              sections={sections}
             />
           </div>
         ) : (

--- a/src/components/EyeSpyPage/EyeSpyPage.jsx
+++ b/src/components/EyeSpyPage/EyeSpyPage.jsx
@@ -92,7 +92,7 @@ export default class EyeSpyPage extends React.Component {
     } = this.state;
 
     return (
-      <div className="app app-tour-page">
+      <div className="app app-eyespy-page">
         <SiteHtmlHelmetHead metaTags={this.getMetaTags(title)} />
         <HtmlClassManager />
         <SiteHeader isTour />

--- a/src/components/EyeSpyPage/EyeSpyPage.jsx
+++ b/src/components/EyeSpyPage/EyeSpyPage.jsx
@@ -38,6 +38,7 @@ export default class EyeSpyPage extends React.Component {
         const tourResponse = await axios.get(`/api/tour/eyeSpy/${id}`);
         const tourData = tourResponse.data;
         const objects = tourData.objects;
+        const clues = tourData.clues;
 
         const roomOrder = tourData.customRoomOrder.length
           ? tourData.customRoomOrder
@@ -46,7 +47,7 @@ export default class EyeSpyPage extends React.Component {
         const heroImageId = tourData.heroImageId;
         const object = objects.find((obj) => parseInt(obj._id) === heroImageId);
         const parsedObject = parseObject(object._source);
-        const sections = formatTourData(roomOrder, objects)
+        const sections = formatTourData(roomOrder, objects, clues)
 
         this.setState({
           title: tourData.title,

--- a/src/components/EyeSpyPage/EyeSpyPage.jsx
+++ b/src/components/EyeSpyPage/EyeSpyPage.jsx
@@ -1,0 +1,121 @@
+import React from "react";
+import axios from "axios";
+import { SiteHeader } from "../../components/SiteHeader/SiteHeader";
+import SiteHtmlHelmetHead from "../SiteHtmlHelmetHead";
+import HtmlClassManager from "../HtmlClassManager";
+import Footer from "../Footer/Footer";
+import StickyList from "../StickyList/StickyList";
+import {
+  META_TITLE,
+  META_DESCRIPTION,
+  DEFAULT_ROOM_ORDER,
+} from "../../constants";
+import { parseObject } from "../../objectDataUtils";
+
+export default class EyeSpyPage extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      tourId: null,
+      title: null,
+      description: null,
+      objects: null,
+      roomOrder: null,
+      heroImgSrc: null,
+      metaImgUrl: null,
+    };
+  }
+
+  async componentDidMount() {
+    // Extract the slug for this tour
+    const { id } = this.props.match.params;
+
+    // If we have a slug, retrieve information for the tour
+    if (id) {
+      try {
+        const tourResponse = await axios.get(`/api/tour/eyeSpy/${id}`);
+        const tourData = tourResponse.data;
+        const objects = tourData.objects;
+
+        const roomOrder = tourData.customRoomOrder.length
+          ? tourData.customRoomOrder
+          : DEFAULT_ROOM_ORDER;
+
+        const heroImageId = tourData.heroImageId;
+        const object = objects.find((obj) => parseInt(obj._id) === heroImageId);
+        const parsedObject = parseObject(object._source);
+
+        this.setState({
+          title: tourData.title,
+          subtitle: tourData.subtitle,
+          description: tourData.description,
+          objects: objects,
+          roomOrder: roomOrder,
+          heroImageSrc: parsedObject.imageUrlLarge,
+          metaImgUrl: parsedObject.imageUrlSmall,
+        });
+      } catch (error) {
+        console.log(
+          `An error occurred retrieving the tour for id ${id}`,
+          error
+        );
+      } finally {
+        this.setState({
+          ...this.state,
+          tourId: id,
+        });
+      }
+    }
+  }
+
+  getMetaTags(title) {
+    const metaTitle = `${META_TITLE} — ${title}`;
+    const metaDescription = `Barnes Foundation Collection: ${title} -- ${META_DESCRIPTION}`;
+
+    return {
+      title: metaTitle,
+      description: metaDescription,
+      image: this.state.metaImgUrl,
+    };
+  }
+
+  render() {
+    const {
+      tourId,
+      title,
+      subtitle,
+      description,
+      roomOrder,
+      objects,
+      heroImageSrc,
+    } = this.state;
+
+    return (
+      <div className="app app-tour-page">
+        <SiteHtmlHelmetHead metaTags={this.getMetaTags(title)} />
+        <HtmlClassManager />
+        <SiteHeader isTour />
+        {tourId && title && objects ? (
+          // Display the tour if it was located
+          <div>
+            <StickyList
+              title={title}
+              subtitle={subtitle}
+              heroImageSrc={heroImageSrc}
+              description={description}
+              objects={objects}
+              sectionOrder={roomOrder}
+            />
+          </div>
+        ) : (
+          // Otherwise, no tour found for that id
+          <div className="container">
+            <p>Could not find tour with id "{tourId}"</p>
+          </div>
+        )}
+        <Footer />
+      </div>
+    );
+  }
+}

--- a/src/components/ObjectCard/ObjectCard.jsx
+++ b/src/components/ObjectCard/ObjectCard.jsx
@@ -1,6 +1,5 @@
 import React, { Component } from "react";
 import classnames from "classnames";
-import { getObjectMetaDataHtml } from "../ArtObjectPageComponents/PanelVisuallyRelated";
 import "./objectCard.css";
 
 export class ObjectCard extends Component {
@@ -65,15 +64,15 @@ export class ObjectCard extends Component {
               invisible: !this.state.metaDataVisible,
             })}
           >
-            {getObjectMetaDataHtml(object)}
+            {object.contentInfo}
           </div>
         </div>
-        {object.shortDescription && (
+        {object.overlayText && (
           <div className="object-card__overlay">
             <div className="object-card__overlay-background">
               <div
                 className="object-card__overlay-text"
-                dangerouslySetInnerHTML={{ __html: object.shortDescription }}
+                dangerouslySetInnerHTML={{ __html: object.overlayText }}
                 ref={(overlayText) => {
                   this.overlayText = overlayText;
                 }}

--- a/src/components/ObjectCard/ObjectCard.jsx
+++ b/src/components/ObjectCard/ObjectCard.jsx
@@ -16,7 +16,7 @@ export class ObjectCard extends Component {
   handleClick(event) {
     event.preventDefault();
 
-    if (this.props.object.shortDescription) {
+    if (this.props.object.overlayText) {
       const showDescription = !this.state.descriptionVisible;
       let showMetaData = true;
 
@@ -72,11 +72,12 @@ export class ObjectCard extends Component {
             <div className="object-card__overlay-background">
               <div
                 className="object-card__overlay-text"
-                dangerouslySetInnerHTML={{ __html: object.overlayText }}
                 ref={(overlayText) => {
                   this.overlayText = overlayText;
                 }}
-              ></div>
+              >
+                {object.overlayText}
+              </div>
             </div>
           </div>
         )}

--- a/src/components/StickyList/StickyList.jsx
+++ b/src/components/StickyList/StickyList.jsx
@@ -1,23 +1,16 @@
 import React, { Component } from "react";
 import classnames from "classnames";
-import { formatTourData } from "../TourPage/tourPageHelper";
 import { StickyListSection } from "../StickyListSection/StickyListSection";
 import "./stickyList.css";
 
 export default class StickyList extends Component {
-  imageAria(object) {
-    const culture = object.culture ? `, ${object.culture}` : "";
-    return `${object.title} by ${object.people}${culture}.`;
-  }
-  
   render() {
     const {
       title,
       subtitle,
       heroImageSrc,
       description,
-      objects,
-      sectionOrder,
+      sections
     } = this.props;
 
     return (
@@ -42,7 +35,7 @@ export default class StickyList extends Component {
           <i>This interactive guide is best viewed on a mobile device.</i>
         </p>
 
-        {formatTourData(sectionOrder, objects).map((section) => (
+        {sections.map((section) => (
           <StickyListSection
             header={section.header}
             key={section.header}

--- a/src/components/StickyList/StickyList.jsx
+++ b/src/components/StickyList/StickyList.jsx
@@ -39,7 +39,7 @@ export default class StickyList extends Component {
           <StickyListSection
             header={section.header}
             key={section.header}
-            section={section}
+            content={section.content}
           />
         ))}
       </div>

--- a/src/components/StickyListSection/StickyListSection.jsx
+++ b/src/components/StickyListSection/StickyListSection.jsx
@@ -1,6 +1,5 @@
 import React, { Component } from "react";
 import classnames from "classnames";
-import { parseObject } from "../../objectDataUtils";
 import { ObjectCard } from "../ObjectCard/ObjectCard";
 import "./stickyListSection.css";
 
@@ -14,8 +13,6 @@ export class StickyListSection extends Component {
 
   componentDidMount() {
     window.addEventListener("scroll", this.handleScroll);
-    const parsedObjects = this.props.content.map((obj) => { return parseObject(obj)})
-    this.setState({ parsedObjects: parsedObjects })
   }
 
   handleScroll(event) {
@@ -55,7 +52,7 @@ export class StickyListSection extends Component {
           </div>
         </div>
         <div className="sticky-list-section__content">
-          {this.state.parsedObjects && this.state.parsedObjects.map((obj) => {
+          {this.props.content.map((obj) => {
             return <ObjectCard object={obj} key={obj.id} />;
           })}
         </div>

--- a/src/components/StickyListSection/StickyListSection.jsx
+++ b/src/components/StickyListSection/StickyListSection.jsx
@@ -14,6 +14,8 @@ export class StickyListSection extends Component {
 
   componentDidMount() {
     window.addEventListener("scroll", this.handleScroll);
+    const parsedObjects = this.props.content.map((obj) => { return parseObject(obj)})
+    this.setState({ parsedObjects: parsedObjects })
   }
 
   handleScroll(event) {
@@ -53,8 +55,8 @@ export class StickyListSection extends Component {
           </div>
         </div>
         <div className="sticky-list-section__content">
-          {this.props.section.content.map((obj) => {
-            return <ObjectCard object={parseObject(obj)} key={obj.id} />;
+          {this.state.parsedObjects && this.state.parsedObjects.map((obj) => {
+            return <ObjectCard object={obj} key={obj.id} />;
           })}
         </div>
       </div>

--- a/src/components/TourPage/TourPage.jsx
+++ b/src/components/TourPage/TourPage.jsx
@@ -11,6 +11,7 @@ import {
   DEFAULT_ROOM_ORDER,
 } from "../../constants";
 import { parseObject } from "../../objectDataUtils";
+import { formatTourData } from "./tourPageHelper";
 
 export default class TourPage extends React.Component {
   constructor(props) {
@@ -45,15 +46,15 @@ export default class TourPage extends React.Component {
         const heroImageId = tourData.heroImageId;
         const object = objects.find((obj) => parseInt(obj._id) === heroImageId);
         const parsedObject = parseObject(object._source);
+        const sections = formatTourData(roomOrder, objects)
 
         this.setState({
           title: tourData.title,
           subtitle: tourData.subtitle,
           description: tourData.description,
-          objects: objects,
-          roomOrder: roomOrder,
           heroImageSrc: parsedObject.imageUrlLarge,
           metaImgUrl: parsedObject.imageUrlSmall,
+          sections: sections,
         });
       } catch (error) {
         console.log(
@@ -86,9 +87,8 @@ export default class TourPage extends React.Component {
       title,
       subtitle,
       description,
-      roomOrder,
-      objects,
       heroImageSrc,
+      sections,
     } = this.state;
 
     return (
@@ -96,7 +96,7 @@ export default class TourPage extends React.Component {
         <SiteHtmlHelmetHead metaTags={this.getMetaTags(title)} />
         <HtmlClassManager />
         <SiteHeader isTour />
-        {tourId && title && objects ? (
+        {tourId && title && sections ? (
           // Display the tour if it was located
           <div>
             <StickyList
@@ -104,8 +104,7 @@ export default class TourPage extends React.Component {
               subtitle={subtitle}
               heroImageSrc={heroImageSrc}
               description={description}
-              objects={objects}
-              sectionOrder={roomOrder}
+              sections={sections}
             />
           </div>
         ) : (

--- a/src/components/TourPage/tourPageHelper.js
+++ b/src/components/TourPage/tourPageHelper.js
@@ -13,7 +13,7 @@ import { getObjectMetaDataHtml } from "../ArtObjectPageComponents/PanelVisuallyR
   // If eye spy tour, set the clue as the caption and object meta data and description as overlay
   if (clues) {
     // Set the clue to be the object caption and object meta + description as overlay text
-    object.contentInfo = (<p>{clues[object.invno]}</p>)
+    object.contentInfo = (<p>{parse(clues[object.invno])}</p>)
     object.overlayText = (
       <div>
         {getObjectMetaDataHtml(object)}

--- a/src/components/TourPage/tourPageHelper.js
+++ b/src/components/TourPage/tourPageHelper.js
@@ -1,21 +1,35 @@
 import { getRoomName } from "../../ensembleIndex";
 
+/**
+ * Given a list of art objects, sorts the list into dictionary with 
+ * room numbers as the keys and an array of art objects as the value
+ */
 export const sortObjectsByRoom = (objects) => {
+  // Obj containing all art objects organized by room
   const objByRoom = {};
   for (const object of objects) {
     const room = getRoomName(object._source.ensembleIndex);
+    // If key for this room doesn't exist, add it
     objByRoom[room] = objByRoom[room] ? objByRoom[room] : [];
+    // Add object to room array
     objByRoom[room].push(object._source);
   }
   return objByRoom;
 };
 
+/**
+ * Given an array with the room numbers in order and an array of art objects, 
+ * returns an array of room objects with the section header and art object content.
+ */
 export const formatTourData = (roomOrder, objects) => {
   const tourData = [];
+  // Get dictionary of art objects organized by room number
   const objByRoom = sortObjectsByRoom(objects);
 
   for (const room of roomOrder) {
+    // If the dictionary has a key for that room, add it to the tourData array
     if (objByRoom[room]) {
+      // Set the header and content for each tour section
       const roomData = {
         header: room,
         content: objByRoom[room],

--- a/src/components/TourPage/tourPageHelper.js
+++ b/src/components/TourPage/tourPageHelper.js
@@ -1,4 +1,25 @@
 import { getRoomName } from "../../ensembleIndex";
+import { parseObject } from "../../objectDataUtils";
+import { getObjectMetaDataHtml } from "../ArtObjectPageComponents/PanelVisuallyRelated";
+
+/**
+ * Given an object, parses the images urls, and sets the content info and overlay text attributes
+ */
+ export const parseTourObject = (object, eyeSpy = false) => {
+  object = parseObject(object);
+  
+  // If eye spy tour, set the clue as the caption and object meta data and description as overlay
+  if (eyeSpy) {
+    // TODO
+
+  // Else default to object meta data as caption and description as overlay text
+  } else {
+    object.contentInfo = getObjectMetaDataHtml(object)
+    object.overlayText = object.shortDescription
+  }
+
+  return object;
+}
 
 /**
  * Given a list of art objects, sorts the list into dictionary with 
@@ -11,8 +32,10 @@ export const sortObjectsByRoom = (objects) => {
     const room = getRoomName(object._source.ensembleIndex);
     // If key for this room doesn't exist, add it
     objByRoom[room] = objByRoom[room] ? objByRoom[room] : [];
+    // Parse the object to set required attributes
+    const parsedObject = parseTourObject(object._source);
     // Add object to room array
-    objByRoom[room].push(object._source);
+    objByRoom[room].push(parsedObject);
   }
   return objByRoom;
 };

--- a/src/components/TourPage/tourPageHelper.js
+++ b/src/components/TourPage/tourPageHelper.js
@@ -1,3 +1,5 @@
+import React from "react";
+import parse from "html-react-parser";
 import { getRoomName } from "../../ensembleIndex";
 import { parseObject } from "../../objectDataUtils";
 import { getObjectMetaDataHtml } from "../ArtObjectPageComponents/PanelVisuallyRelated";
@@ -5,17 +7,23 @@ import { getObjectMetaDataHtml } from "../ArtObjectPageComponents/PanelVisuallyR
 /**
  * Given an object, parses the images urls, and sets the content info and overlay text attributes
  */
- export const parseTourObject = (object, eyeSpy = false) => {
+ export const parseTourObject = (object, clues = undefined) => {
   object = parseObject(object);
   
   // If eye spy tour, set the clue as the caption and object meta data and description as overlay
-  if (eyeSpy) {
-    // TODO
-
+  if (clues) {
+    // Set the clue to be the object caption and object meta + description as overlay text
+    object.contentInfo = (<p>{clues[object.invno]}</p>)
+    object.overlayText = (
+      <div>
+        {getObjectMetaDataHtml(object)}
+        {object.shortDescription.length ? parse(object.shortDescription) : <span></span>}
+      </div>
+    )
   // Else default to object meta data as caption and description as overlay text
   } else {
     object.contentInfo = getObjectMetaDataHtml(object)
-    object.overlayText = object.shortDescription
+    object.overlayText = parse(object.shortDescription)
   }
 
   return object;
@@ -25,15 +33,16 @@ import { getObjectMetaDataHtml } from "../ArtObjectPageComponents/PanelVisuallyR
  * Given a list of art objects, sorts the list into dictionary with 
  * room numbers as the keys and an array of art objects as the value
  */
-export const sortObjectsByRoom = (objects) => {
+export const sortObjectsByRoom = (objects, clues = undefined) => {
   // Obj containing all art objects organized by room
   const objByRoom = {};
   for (const object of objects) {
+    // Get room name from the ensemble index
     const room = getRoomName(object._source.ensembleIndex);
     // If key for this room doesn't exist, add it
     objByRoom[room] = objByRoom[room] ? objByRoom[room] : [];
     // Parse the object to set required attributes
-    const parsedObject = parseTourObject(object._source);
+    const parsedObject = parseTourObject(object._source, clues);
     // Add object to room array
     objByRoom[room].push(parsedObject);
   }
@@ -44,10 +53,10 @@ export const sortObjectsByRoom = (objects) => {
  * Given an array with the room numbers in order and an array of art objects, 
  * returns an array of room objects with the section header and art object content.
  */
-export const formatTourData = (roomOrder, objects) => {
+export const formatTourData = (roomOrder, objects, clues = undefined) => {
   const tourData = [];
   // Get dictionary of art objects organized by room number
-  const objByRoom = sortObjectsByRoom(objects);
+  const objByRoom = sortObjectsByRoom(objects, clues);
 
   for (const room of roomOrder) {
     // If the dictionary has a key for that room, add it to the tourData array

--- a/src/components/TourPage/tourPageHelper.test.js
+++ b/src/components/TourPage/tourPageHelper.test.js
@@ -1,9 +1,7 @@
 import { sortObjectsByRoom, formatTourData } from "./tourPageHelper";
 import { DEFAULT_ROOM_ORDER } from "../../constants";
 
-const objects = require("../../../server/constants/tours/test")["data"]["hits"][
-  "hits"
-];
+const objects = require("../../../server/constants/tours/test")["objects"];
 
 describe("sortObjectsByRoom", () => {
   const objByRoom = sortObjectsByRoom(objects);

--- a/src/objectDataUtils.js
+++ b/src/objectDataUtils.js
@@ -16,11 +16,13 @@ const generateObjectImageUrls = (object) => {
 
   const canonicalRoot = (process.env.REACT_APP_CANONICAL_ROOT || '')
   const canonicalRootNoProt = canonicalRoot.replace(/^https?:\/\//i, '')
+  // Clone existing object
   const newObject = Object.assign({}, object)
   const imageTrackBaseUrl = `/track/image-download/`
   const imageIdReg = `${object.id}_${object.imageSecret}`
   const imageIdOrig = `${object.id}_${object.imageOriginalSecret}`
 
+  // Construct image urls for object with updated url roots
   newObject.imageUrlSmall = `${imageUrlBase}/${imageIdReg}_n.jpg`;
   newObject.imageUrlOriginal = `${imageUrlBase}/${imageIdOrig}_o.jpg`;
   newObject.imageUrlLarge = `${imageUrlBase}/${imageIdReg}_b.jpg`;
@@ -32,6 +34,7 @@ const generateObjectImageUrls = (object) => {
 const sanitizeEnsembleIndex = (object) => {
   let index = object.ensembleIndex;
 
+  // Update the ensemble index
   object.ensembleIndex = index ? index.split(',')[0] : null;
 
   return object;

--- a/src/routeSwitcher.jsx
+++ b/src/routeSwitcher.jsx
@@ -5,6 +5,7 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 
 import TourPage from './components/TourPage/TourPage';
+import EyeSpyPage from './components/EyeSpyPage/EyeSpyPage';
 import LandingPage from './components/LandingPage/LandingPage';
 import ArtObjectPage from './components/ArtObjectPage/ArtObjectPage';
 import ArtObjectPageModal from './components/ArtObjectPageComponents/ArtObjectPageModal';
@@ -91,6 +92,8 @@ class RouteSwitcher extends Component {
           <Route exact path='/objects/:id/:title/:panel' component={ArtObjectPage} />
           <Route exact path='/tour' component={LandingPage}/>
 		      <Route path='/tour/:id' component={TourPage} />
+          <Route exact path='/eye-spy' component={LandingPage}/>
+		      <Route path='/eye-spy/:id' component={EyeSpyPage} />
         </Switch>
         {this.modalRouteComponents}
       </div>


### PR DESCRIPTION
## Description
Adds the route for eye spy tours on the front end and refactors the Sticky List components to work for both eye spy and standard tours. Updated helper functions so that they will parse the content for the tour pages. Adds the JSON file for the Dec 2021 eye spy tour.

## Jira
https://barnesfoundation.atlassian.net/browse/CS-22
https://barnesfoundation.atlassian.net/browse/CS-24