### PR TITLE
Generate search assets in deployment pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
 		"build": "npm run build-css && react-scripts build",
 		"postbuild": "gulp",
 		"build-sitemap": "node scripts/build-sitemap.js",
+		"write-search-assets": "node scripts/write-search-assets.js",
 		"start": "node server/index.js",
 		"server-dev": "PORT=4002 nodemon server/index.js",
 		"client": "PORT=3002 react-scripts start",

--- a/scripts/build-search-assets.js
+++ b/scripts/build-search-assets.js
@@ -119,11 +119,17 @@ const generateAssets = async () => {
 	};
 
 	const searchAssetsDocument = JSON.stringify(searchAssetsObject, null, '\t');
-	const result = await writeAssetsFile('searchAssets.json', searchAssetsDocument);
+	return searchAssetsDocument;
+}
 
+/** Executes the work to generate the search assets and write to local file */
+const generateAndWriteAssets = async () => {
+	const searchAssetsDocument = await generateAssets();
+	const result = await writeAssetsFile("searchAssets.json", searchAssetsDocument);
 	return result;
 }
 
 module.exports = {
-	generateAssets
+	generateAssets,
+	generateAndWriteAssets,
 }

--- a/scripts/write-search-assets.js
+++ b/scripts/write-search-assets.js
@@ -1,0 +1,34 @@
+const axios = require('axios');
+const fs = require('fs');
+const path = require('path')
+
+const apiUrl = "https://collection.barnesfoundation.org/api/get-search-assets";
+const constantsDirectory = path.resolve(__dirname, '../public/resources');
+
+const logError = (errorMsg) => {
+	console.log('Oops, Something went wrong while trying to build the search assets.')
+	console.log(errorMsg)
+}
+
+const fetchSearchAssets = () => {
+	return axios.get(apiUrl).catch((error) => {
+		logError(error)
+	})
+}
+
+const writeSearchAssetsFile = (text, onSuccess) => {
+	const pathName = path.join(constantsDirectory, "searchAssets.json");
+	fs.writeFile(pathName, text, (error) => {
+		if (error) {
+			return logError(error);
+		}
+
+		onSuccess();
+	})
+}
+
+fetchSearchAssets().then(response => {
+	writeSearchAssetsFile(response.data, () => {
+		console.log("Search assets generated in public/resources/searchAssets.json 👍")
+	})
+})

--- a/server/app.js
+++ b/server/app.js
@@ -519,8 +519,14 @@ app.get(`${imageTrackBaseUrl}:imageId`, (req, res) => {
   }).send()
 })
 
-/** Endpoint for generating the assets file for the frontend */
+/** Endpoint for locally generating the assets file for the frontend */
 app.use('/api/build-search-assets', async (req, res) => {
+	const result = await buildSearchAssets.generateAndWriteAssets();
+	res.json(result);
+});
+
+/** Endpoint for generating the assets file during deployment */
+app.use('/api/get-search-assets', async (req, res) => {
 	const result = await buildSearchAssets.generateAssets();
 	res.json(result);
 });


### PR DESCRIPTION
## Description
The original scrip to generate the search assets relied on the local server to be running to generate and write the file. I updated the logic of the original script so that it returns a function that generates the JSON and another fn that generates the JSON and writes it to a file (for local development). I then created new endpoint that returns the search assets json and created npm script for writing the file, similar to the npm script for writing the sitemap. The new script will hit the prod collection API to generate the JSON for the searchAssets and then write it locally. The new script was created mainly for the purpose of using it in the AWS codepipeline so we can automate deployments. 