### PR TITLE
Release 1/13/22 - 2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3327,6 +3327,7 @@
 			"version": "0.0.9",
 			"resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
 			"integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+			"dev": true,
 			"requires": {
 				"inherits": "~2.0.0"
 			}
@@ -17776,6 +17777,7 @@
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
 			"integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
+			"dev": true,
 			"requires": {
 				"block-stream": "*",
 				"fstream": "^1.0.12",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
 		"sshpk": "^1.13.2",
 		"stringstream": "^0.0.6",
 		"symbol-observable": "^1.0.4",
-		"tar": "^2.2.2",
 		"tunnel-agent": "^0.6.0",
 		"universal-analytics": "^0.4.16",
 		"url-parse": "^1.5.2",


### PR DESCRIPTION
- Removes tar dependency, which was unused and had a security vulnerability