### PR TITLE
CS-38-fix-collection-bugs

### DIFF
--- a/src/ensembleIndex.js
+++ b/src/ensembleIndex.js
@@ -10,12 +10,15 @@ export const ENSEMBLE_IMAGE_URL = (index) => {
 }
 
 export const getRoomAndTitleText = (ensembleIndex) => {
-  const wallTitle = ENSEMBLE[ensembleIndex].wallTitle;
+  const ensembleInfo = ENSEMBLE[ensembleIndex];
+  if (!ensembleInfo) return '';
+
+  const wallTitle = ensembleInfo.wallTitle;
   const wallTitleStr = wallTitle ? `, ${wallTitle}` : '';
 
-  return `${ENSEMBLE[ensembleIndex].roomTitle}${wallTitleStr}`;
+  return `${ensembleInfo.roomTitle}${wallTitleStr}`;
 }
 
 export const getRoomName = (ensembleIndex) => {
-  return ENSEMBLE[ensembleIndex].roomTitle;
+  return ENSEMBLE[ensembleIndex] ? ENSEMBLE[ensembleIndex].roomTitle : '';
 };


### PR DESCRIPTION
https://barnesfoundation.atlassian.net/browse/CS-38

Andrea and Robin mentioned to me that [this object in the Collection site](https://collection.barnesfoundation.org/objects/7197/Study-for-the-Dance-Mural/) displays incorrect information, in that these fields are not rendering any information, even though the record does have data for these fields

- Year
- Medium
- Accession Number
- Dimensions

In doing some investigation, this is a bug occurring on the Collection site. There's actually some errors logged in the Chrome console when rendering this artwork on the live site. 

The error was due to this record not having an ensemble index, and the code we changed below expects every record to have an ensemble index. This code is called for all objects that are on-view, so we can generate the room title and text shown in the object detail.

These 3 artworks will demonstrate this problem on the site
- 6083 
- 7197 
- 3370