### PR TITLE
add-new-copyright-configuration

### DIFF
--- a/src/components/ArtObjectPageComponents/PanelDetails/index.jsx
+++ b/src/components/ArtObjectPageComponents/PanelDetails/index.jsx
@@ -360,7 +360,6 @@ class PanelDetails extends Component {
           <div className='container-inner-narrow'>
             <SummaryTable {...object} objectCopyrightDetails={objectCopyrightDetails} />
             <div className='m-block m-block--no-border m-block--shallow m-block--flush-top download-and-share'>
-              {/* Removed rel='noopener noreferrer nofollow' from the following links. */}
               <a
                 className='btn btn--primary btn--100 btn--vertically-center'
                 href={objectCopyrightDetails.type === 'large' ? downloadRequestUrl : requestImageUrl}

--- a/src/copyrightMap.js
+++ b/src/copyrightMap.js
@@ -38,6 +38,11 @@ const COPYRIGHT = {
     copy: 'Public Domain',
     link: 'https://creativecommons.org/publicdomain/mark/1.0/',
     type: 'large'
+  },
+  11: {
+    copy: 'Public Domain, Temporarily Under Exclusive License',
+    link: 'https://creativecommons.org/publicdomain/mark/1.0/',
+    type: 'large-exclusive'
   }
 };
 


### PR DESCRIPTION
This change just introduces an additional configuration element to our `COPYRIGHT` array in `coprightMap.js`.

We have a need to introduce a new copyright configuration that _is actually Public _Domain_ but that still requires a user to go through the workflow of requesting the image for download prior to obtaining a copy of the image. This new configuration has a download restriction similar to when an object is under copyright.

I've done this by adding the new element to the map, Two requirements before this can fully go live

1. It will require these objects to have a `objRightsTypeId` value of `11` (or whatever arbitrary value) to come upstream from TMS/eMuseum so it can be synced over during the nightly data processing sync
2. I need Steve to let me know if objects that fall under this temporary copyright designation should still allow zooming of their image tileset

Once I get the above answered, I can merge this in. Below is an example of how this will look when live. Note: This object does not actually have this copyright restriction, I merely simulated it by setting its `objRightTypesId` to `11` for demo purposes.

![image](https://github.com/BarnesFoundation/Barnes-Online-Collection/assets/41299115/3e7d38e6-5a11-454d-b64e-03b65305f837)
