### PR TITLE
make-netx-integration-enabled-disabled-via-react-app

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -9,7 +9,7 @@ ELASTICSEARCH_INDEX=<set to override - defaults to latest complete collection in
 # NetX configuration
 NETX_BASE_URL=<url_for_netx_instance>
 NETX_API_TOKEN=<api_token_from_netx>
-NETX_ENABLED=false
+REACT_APP_NETX_ENABLED=false
 
 # AWS Credentials and configuration
 AWS_BUCKET=<s3_bucket_for_all_images>

--- a/server/services/damsService.js
+++ b/server/services/damsService.js
@@ -2,7 +2,6 @@ const axios = require("axios");
 
 const NETX_BASE_URL = process.env.NETX_BASE_URL;
 const NETX_API_TOKEN = process.env.NETX_API_TOKEN;
-const NETX_ENABLED = process.env.NETX_ENABLED || false;
 
 function generateGetAssetQuery(objectId) {
   return {
@@ -50,12 +49,9 @@ function generateGetAssetQuery(objectId) {
   };
 }
 
+/** Function that receives an Object ID parameter and
+ *  returns the available assets from the DAMS for it */
 async function getAssetByObjectId(objectId) {
-  // In case we want to disable interaction with NetX for now
-  if (NETX_ENABLED === false) {
-    return [];
-  }
-
   const response = await axios({
     baseURL: NETX_BASE_URL,
     url: "/api/rpc",

--- a/src/components/ArtObjectPageComponents/PanelDetails/index.jsx
+++ b/src/components/ArtObjectPageComponents/PanelDetails/index.jsx
@@ -14,9 +14,7 @@ import { getObjectCopyright } from '../../../copyrightMap';
 import { ShareDialog } from '../../ShareDialog/ShareDialog';
 import './index.css';
 
-// For now, renditions are not enabled
-const ENABLE_ADDITIONAL_RENDITIONS = false;
-
+const ENABLE_ADDITIONAL_RENDITIONS = process.env.REACT_APP_NETX_ENABLED;
 const DEFAULT_THUMBNAIL_COUNT = 5;
 
 const getTabList = (artObjectProps) => (
@@ -282,8 +280,8 @@ class PanelDetails extends Component {
   }
 
 
-  /** Async method to fetch possible additional renditions for this object */
   async componentDidUpdate() {
+      /** Fetch possible additional renditions for this object - only when enabled */
     if (ENABLE_ADDITIONAL_RENDITIONS && this.props.object.id && this.state.renditions === null) {
       try {
         const response = await axios({


### PR DESCRIPTION
https://barnesfoundation.atlassian.net/browse/CS-46

Converted the `NETX_ENABLED` environment variable to a React environment variable named `REACT_APP_NETX_ENABLED`. I've modified the server-side function for retrieving renditions from NetX to return actual data _always_ and allow for controlling NetX functionality being enabled from the React side.

This way, we can easily set the React environment variable to true and start displaying renditions. The endpoint in the server will always be live - just not always in use per the React environment variable.