### PR TITLE
DAMS-10-verify-link-between-archival-images-to-artwork-record

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -7,8 +7,8 @@ ELASTICSEARCH_PROTOCOL=https
 ELASTICSEARCH_INDEX=<set to override - defaults to latest complete collection index>
 
 # NetX configuration
-NETX_BASE_URL=<url_for_netx_instance>
 NETX_API_TOKEN=<api_token_from_netx>
+REACT_APP_NETX_BASE_URL=<url_for_netx_instance>
 REACT_APP_NETX_ENABLED=false
 
 # AWS Credentials and configuration

--- a/server/app.js
+++ b/server/app.js
@@ -576,7 +576,11 @@ app.get("/api/eye-spy/:id", tourService.getTour);
 
 /** Endpoint for retrieving asset information from the NetX DAMS */
 app.get("/api/objects/:id/assets", async (request, response) => {
-  const result = await damsService.getAssetByObjectId(request.params.id);
+  // The object number needs to go from a schema of "01.02.09" to "01_02_09"
+  // to conform with the DAMS naming schema for rendition names
+  const objectNumber = request.params.id.replace(/\./g, "_");
+  const result = await damsService.getAssetByObjectNumber(objectNumber);
+
   response.json(result);
 });
 

--- a/server/services/damsService/damsService.js
+++ b/server/services/damsService/damsService.js
@@ -1,0 +1,58 @@
+const axios = require("axios");
+const {
+  generateGetFolderByPathQuery,
+} = require("./generateGetFolderByPathQuery");
+const {
+  generateGetAssetsByFolderQuery,
+} = require("./generateGetAssetsByFolderQuery");
+
+const NETX_BASE_URL = process.env.NETX_BASE_URL;
+const NETX_API_TOKEN = process.env.NETX_API_TOKEN;
+const NETX_ENABLED = process.env.NETX_ENABLED || false;
+
+async function makeNetXRequest(query) {
+  const response = await axios({
+    baseURL: NETX_BASE_URL,
+    url: "/api/rpc",
+    method: "POST",
+    headers: {
+      Authorization: `apiToken ${NETX_API_TOKEN}`,
+    },
+    data: query,
+  });
+
+  return response;
+}
+
+async function getAssetByObjectNumber(objectNumber) {
+  // In case we want to disable interaction with NetX for now
+  if (NETX_ENABLED === false) {
+    return [];
+  }
+
+  // We'll check to see if we there exists a sub-folder
+  // for this Object Number at the below folder path
+  const folderQueryResponse = await makeNetXRequest(
+    generateGetFolderByPathQuery(objectNumber)
+  );
+  const result = folderQueryResponse.data.result || null;
+
+  // This means there's no assets for the provided Object Number
+  if (result === null) {
+    return [];
+  }
+
+  // Otherwise, the assets are existent at the path
+  // So we can use the `getAssetsByFolder` query to retrieve the assets
+  const { id } = result;
+  const assetQueryResponse = await makeNetXRequest(
+    generateGetAssetsByFolderQuery(id)
+  );
+
+  const assets = assetQueryResponse.data.result.results;
+  return assets;
+}
+
+module.exports = {
+  getAssetByObjectNumber,
+};

--- a/server/services/damsService/damsService.js
+++ b/server/services/damsService/damsService.js
@@ -27,7 +27,6 @@ async function makeNetXRequest(query) {
 
 async function getAssetByObjectNumber(objectNumber) {
   // In case we want to disable interaction with NetX for now
-  console.log(NETX_ENABLED === false);
   if (NETX_ENABLED === false) {
     return [];
   }
@@ -46,9 +45,8 @@ async function getAssetByObjectNumber(objectNumber) {
 
   // Otherwise, the assets are existent at the path
   // So we can use the `getAssetsByFolder` query to retrieve the assets
-  const { id } = result;
   const assetQueryResponse = await makeNetXRequest(
-    generateGetAssetsByFolderQuery(id)
+    generateGetAssetsByFolderQuery(result.id)
   );
 
   const assets = assetQueryResponse.data.result.results;

--- a/server/services/damsService/damsService.js
+++ b/server/services/damsService/damsService.js
@@ -6,9 +6,9 @@ const {
   generateGetAssetsByFolderQuery,
 } = require("./generateGetAssetsByFolderQuery");
 
-const NETX_BASE_URL = process.env.NETX_BASE_URL;
 const NETX_API_TOKEN = process.env.NETX_API_TOKEN;
-const NETX_ENABLED = process.env.NETX_ENABLED || false;
+const NETX_BASE_URL = process.env.REACT_APP_NETX_BASE_URL;
+const NETX_ENABLED = process.env.REACT_APP_NETX_ENABLED || false;
 
 async function makeNetXRequest(query) {
   const response = await axios({

--- a/server/services/damsService/damsService.js
+++ b/server/services/damsService/damsService.js
@@ -8,7 +8,8 @@ const {
 
 const NETX_API_TOKEN = process.env.NETX_API_TOKEN;
 const NETX_BASE_URL = process.env.REACT_APP_NETX_BASE_URL;
-const NETX_ENABLED = process.env.REACT_APP_NETX_ENABLED || false;
+const NETX_ENABLED =
+  process.env.REACT_APP_NETX_ENABLED === "false" ? false : true || false;
 
 async function makeNetXRequest(query) {
   const response = await axios({
@@ -26,6 +27,7 @@ async function makeNetXRequest(query) {
 
 async function getAssetByObjectNumber(objectNumber) {
   // In case we want to disable interaction with NetX for now
+  console.log(NETX_ENABLED === false);
   if (NETX_ENABLED === false) {
     return [];
   }

--- a/server/services/damsService/generateAssetQuery.js
+++ b/server/services/damsService/generateAssetQuery.js
@@ -1,9 +1,3 @@
-const axios = require("axios");
-
-const NETX_BASE_URL = process.env.NETX_BASE_URL;
-const NETX_API_TOKEN = process.env.NETX_API_TOKEN;
-const NETX_ENABLED = process.env.NETX_ENABLED || false;
-
 function generateGetAssetQuery(objectId) {
   return {
     jsonrpc: "2.0",
@@ -50,25 +44,6 @@ function generateGetAssetQuery(objectId) {
   };
 }
 
-async function getAssetByObjectId(objectId) {
-  // In case we want to disable interaction with NetX for now
-  if (NETX_ENABLED === false) {
-    return [];
-  }
-
-  const response = await axios({
-    baseURL: NETX_BASE_URL,
-    url: "/api/rpc",
-    method: "POST",
-    headers: {
-      Authorization: `apiToken ${NETX_API_TOKEN}`,
-    },
-    data: generateGetAssetQuery(objectId),
-  });
-
-  return response.data.result.results;
-}
-
 module.exports = {
-  getAssetByObjectId,
+  generateGetAssetQuery,
 };

--- a/server/services/damsService/generateGetAssetsByFolderQuery.js
+++ b/server/services/damsService/generateGetAssetsByFolderQuery.js
@@ -1,0 +1,24 @@
+function generateGetAssetsByFolderQuery(folderId) {
+  return {
+    id: "13576991614322",
+    method: "getAssetsByFolder",
+    params: [
+      folderId,
+      false,
+      {
+        data: [
+          "asset.id",
+          "asset.base",
+          "asset.attributes",
+          "asset.file",
+          "asset.proxies",
+        ],
+      },
+    ],
+    jsonrpc: "2.0",
+  };
+}
+
+module.exports = {
+  generateGetAssetsByFolderQuery,
+};

--- a/server/services/damsService/generateGetFolderByPathQuery.js
+++ b/server/services/damsService/generateGetFolderByPathQuery.js
@@ -1,0 +1,19 @@
+const COLLECTION_WEBSITE_API_FOLDER = "Collection Website API";
+
+function generateGetFolderByPathQuery(objectNumberWithUnderscores) {
+  return {
+    id: "13576991614322",
+    method: "getFolderByPath",
+    params: [
+      `${COLLECTION_WEBSITE_API_FOLDER}/${objectNumberWithUnderscores}`,
+      {
+        data: ["folder.id", "folder.base", "folder.children"],
+      },
+    ],
+    jsonrpc: "2.0",
+  };
+}
+
+module.exports = {
+  generateGetFolderByPathQuery,
+};

--- a/server/services/damsService/index.js
+++ b/server/services/damsService/index.js
@@ -1,0 +1,5 @@
+const { getAssetByObjectNumber } = require("./damsService");
+
+module.exports = {
+  getAssetByObjectNumber,
+};

--- a/src/components/ArtObjectPageComponents/PanelDetails/index.jsx
+++ b/src/components/ArtObjectPageComponents/PanelDetails/index.jsx
@@ -224,9 +224,6 @@ class Image extends Component {
       imageUrlToRender = object.imageUrlLarge;
     }
 
-    console.log('activeImageIndex', activeImageIndex);
-    console.log('imageUrlToRender', imageUrlToRender);
-
     return (
       <div>
         <div className='image-art-object'>

--- a/src/components/ArtObjectPageComponents/PanelDetails/index.jsx
+++ b/src/components/ArtObjectPageComponents/PanelDetails/index.jsx
@@ -217,7 +217,7 @@ class Image extends Component {
       const imageThumbnailPreview = renditions[activeImageIndex].proxies.find((proxy) => {
         return proxy.name === 'Preview'
       });
-      imageUrlToRender = `https://barnesfoundation.netx.net${imageThumbnailPreview.file.url}/`;
+      imageUrlToRender = `${ui.netxBaseURL}${imageThumbnailPreview.file.url}/`;
     }  
     
     // Otherwise, no renditions exist so we'll render the default image

--- a/src/components/ArtObjectPageComponents/PanelDetails/index.jsx
+++ b/src/components/ArtObjectPageComponents/PanelDetails/index.jsx
@@ -13,6 +13,7 @@ import * as PrintActions from '../../../actions/prints';
 import { getObjectCopyright } from '../../../copyrightMap';
 import { ShareDialog } from '../../ShareDialog/ShareDialog';
 import './index.css';
+import { ui } from "../../../shared/config";
 
 const ENABLE_ADDITIONAL_RENDITIONS = process.env.REACT_APP_NETX_ENABLED;
 const DEFAULT_THUMBNAIL_COUNT = 5;
@@ -66,7 +67,7 @@ class Thumbnail extends Component {
       return proxy.name === 'Thumbnail'
     });
 
-    const imageSourceUrl = `https://barnesfoundation.netx.net${imageThumbnailProxy.file.url}/`;
+    const imageSourceUrl = `${ui.netxBaseURL}${imageThumbnailProxy.file.url}/`;
     const renditionCaption = rendition.attributes['Artwork Caption (TMS)'] || '';
     
     // Set up classNames, if selected add BEM modifier.

--- a/src/components/ArtObjectPageComponents/PanelDetails/index.jsx
+++ b/src/components/ArtObjectPageComponents/PanelDetails/index.jsx
@@ -149,7 +149,10 @@ const Thumbnails = ({ activeImageIndex, setActiveImageIndex, object, isOpen, tog
           </ul>
         </div>
       </div>
-      <div className={panelButtonClassNames}>
+      {/** We only need to render the "View More/View Less" section when we have more 
+       *  renditions than our default count. At that point, we need to expand the thumbnail row
+       */}
+      {renditions?.length >  DEFAULT_THUMBNAIL_COUNT  ? <div className={panelButtonClassNames}>
         <div
           className='panel-button__content'
           onClick={toggleOpen}
@@ -161,7 +164,8 @@ const Thumbnails = ({ activeImageIndex, setActiveImageIndex, object, isOpen, tog
             {!isOpen ? 'View More' : 'View Less'}
           </span>
         </div>
-      </div>
+      </div> : null
+}
     </div>
   ); 
 };
@@ -196,29 +200,33 @@ class Image extends Component {
 
     // This indicates that there was an error with rendering the Zoom component
     const { didCatchFailure } = this.state;
-    const showZoomImageView = Boolean(!didCatchFailure && object.id && activeImageIndex === 0);
     const renditionsExist = renditions?.length > 0;
+    const showZoomImageView = Boolean(!didCatchFailure && object.id && !renditionsExist && activeImageIndex === 0);
 
     let additionalStyle = {};
     let imageUrlToRender = '';
 
     // If we encountered failure during rendering of the Zoom component, we'll hide it
     // Additionally, if the user clicked on an image from the rendition thumbnails, we'll render it instead
-    if (!didCatchFailure && activeImageIndex === 0) {
+    if (!didCatchFailure && !renditionsExist && activeImageIndex === 0) {
       additionalStyle = { ...additionalStyle, display: 'none' };
     };
 
-    // We'll render the image from the object itself 
-    if (activeImageIndex === 0) {
-      imageUrlToRender = object.imageUrlLarge
-    }  // Otherwise, one of the renditions was clicked. So we need to render that image
-    else {
+    // We'll render the image from the object renditions itself 
+    if (renditionsExist) {
       const imageThumbnailPreview = renditions[activeImageIndex].proxies.find((proxy) => {
         return proxy.name === 'Preview'
       });
       imageUrlToRender = `https://barnesfoundation.netx.net${imageThumbnailPreview.file.url}/`;
+    }  
+    
+    // Otherwise, no renditions exist so we'll render the default image
+    else {
+      imageUrlToRender = object.imageUrlLarge;
     }
 
+    console.log('activeImageIndex', activeImageIndex);
+    console.log('imageUrlToRender', imageUrlToRender);
 
     return (
       <div>

--- a/src/components/ArtObjectPageComponents/PanelDetails/index.jsx
+++ b/src/components/ArtObjectPageComponents/PanelDetails/index.jsx
@@ -214,10 +214,9 @@ class Image extends Component {
 
     // We'll render the image from the object renditions itself 
     if (renditionsExist) {
-      const imageThumbnailPreview = renditions[activeImageIndex].proxies.find((proxy) => {
-        return proxy.name === 'Preview'
-      });
-      imageUrlToRender = `${ui.netxBaseURL}${imageThumbnailPreview.file.url}/`;
+      // We have to build the image URL from the asset information
+      const asset = renditions[activeImageIndex];
+      imageUrlToRender = `${ui.netxBaseURL}/api/file/asset/${asset.id}/${asset.fileName}`;
     }  
     
     // Otherwise, no renditions exist so we'll render the default image

--- a/src/components/ArtObjectPageComponents/PanelDetails/index.jsx
+++ b/src/components/ArtObjectPageComponents/PanelDetails/index.jsx
@@ -15,7 +15,7 @@ import { ShareDialog } from '../../ShareDialog/ShareDialog';
 import './index.css';
 import { ui } from "../../../shared/config";
 
-const ENABLE_ADDITIONAL_RENDITIONS = process.env.REACT_APP_NETX_ENABLED;
+const ENABLE_ADDITIONAL_RENDITIONS = process.env.REACT_APP_NETX_ENABLED === 'true' ? true : false;
 const DEFAULT_THUMBNAIL_COUNT = 5;
 
 const getTabList = (artObjectProps) => (

--- a/src/components/ArtObjectPageComponents/PanelDetails/index.jsx
+++ b/src/components/ArtObjectPageComponents/PanelDetails/index.jsx
@@ -288,7 +288,7 @@ class PanelDetails extends Component {
       try {
         const response = await axios({
           method: 'GET',
-          url: `/api/objects/${this.props.object.id}/assets`
+          url: `/api/objects/${this.props.object.invno}/assets`
         });
   
         this.setState({...this.state, renditions: response.data || []})

--- a/src/shared/config/ui.js
+++ b/src/shared/config/ui.js
@@ -7,6 +7,9 @@ module.exports = {
     "https://collection.barnesfoundation.org",
   newsletterURL: process.env.REACT_APP_NEWSLETTER_URL,
 
+  // NetX instance url
+  netxBaseURL: process.env.REACT_APP_NETX_BASE_URL || "",
+
   // Image related values
   awsBucket: process.env.REACT_APP_AWS_BUCKET || "",
   imagesPrefix: process.env.REACT_APP_IMAGES_PREFIX || "",


### PR DESCRIPTION
This pull request does the following
- Adjust the queries used to query against the NetX API in order to retrieve the renditions for a given Object Number. Prior, we only needed one query and the Object ID. Now, based off the new structure in our `Collection Website API` folder, we need the Object Number _and_ to check for a sub-folder in the `Collection Website API` for folder that matches the Object Number
- Allows the NetX Base URL used to access rendition images with to be a dynamic REACT_APP variable since UAT and Production environments are not the exact same
- Renditions the rendition images from NetX _instead_ of the normal object image we receive from ElasticSearch

This closes 
- https://barnesfoundation.atlassian.net/browse/DAMS-11
- https://barnesfoundation.atlassian.net/browse/DAMS-10

And gets us closer to successfully rendering the Archive Correspondence images in the Collection. However, because they are in a restricted folder to our API integration, we are not able to successfully fetch the image without our API credentials, which are not possible to supply when rendering the image using the `<img src />` tag and attribute. This results in a 403 error from accessing the image URL from NetX.

Fetching a few images from NetX also results in a 500 because the asset file appears to be missing somehow, even though we do have the thumbnails available.

I will make 2 tickets to have the DAMS team check this out as this can only be fixed/permitted from their end.