### PR TITLE
DAMS-12-ensure-correct-order-of-rendition-views-using-primary-display-image

### DIFF
--- a/src/components/ArtObjectPageComponents/PanelDetails/index.jsx
+++ b/src/components/ArtObjectPageComponents/PanelDetails/index.jsx
@@ -215,8 +215,10 @@ class Image extends Component {
     // We'll render the image from the object renditions itself 
     if (renditionsExist) {
       // We have to build the image URL from the asset information
-      const asset = renditions[activeImageIndex];
-      imageUrlToRender = `${ui.netxBaseURL}/api/file/asset/${asset.id}/${asset.fileName}`;
+      const imagePreview = renditions[activeImageIndex].proxies.find((proxy) => {
+        return proxy.name === 'Preview'
+      });
+      imageUrlToRender = `${ui.netxBaseURL}${imagePreview.file.url}/`;
     }  
     
     // Otherwise, no renditions exist so we'll render the default image


### PR DESCRIPTION
https://barnesfoundation.atlassian.net/browse/DAMS-12

This pull request does the following
- Shifts the Primary Display Image for an artworks renditions to the front of the image list - so it'll be shown first on the Collection object page
- Shifts the Archive Correspondence images to the end of the image list so they're shown last
- Changes the image view we use for rendering on the Collection Site to be the Preview instead of Full image