### PR TITLE
load-all-images-from-netx-when-possible

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,27 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Launch server.js via nodemon",
+      "type": "node",
+      "runtimeVersion": "12.22",
+      "request": "launch",
+      "runtimeExecutable": "${workspaceFolder}/node_modules/nodemon/bin/nodemon.js",
+      "program": "${workspaceFolder}/server/index.js",
+      "restart": true,
+      "console": "internalConsole",
+      "internalConsoleOptions": "neverOpen",
+      // "outFiles": ["${workspaceFolder}/dist/**/*.js"]
+    },
+    {
+      "type": "chrome",
+      "request": "launch",
+      "name": "Launch Chrome against localhost",
+      "url": "http://localhost:3001",
+      "webRoot": "${workspaceFolder}"
+    }
+  ]
+}

--- a/server/app.js
+++ b/server/app.js
@@ -17,7 +17,6 @@ const googleUA = require("universal-analytics");
 const htpasswdFilePath = path.resolve(__dirname, "../.htpasswd");
 const { ui, meta } = require("../src/shared/config");
 const { generateObjectImageUrls } = require("../src/shared/utils");
-const { transformInvno } = require("./utils/transformInvno");
 
 // using this instead of ejs to template from the express routes after we fetch object data.
 // because the webpack compiler is already using ejs.
@@ -40,7 +39,6 @@ const craftService = require("./services/craftService");
 const tourService = require("./services/tourService");
 const elasticSearchService = require("./services/elasticSearchService");
 const objectAssetService = require("./services/objectAssetService");
-const damsService = require("./services/damsService");
 const {
   BARNES_SETTINGS,
   ALL_MORE_LIKE_THIS_FIELDS,
@@ -183,7 +181,7 @@ app.use("/api/search", async (req, res) => {
     return searchResponse;
   }
 
-  const artworkAssetsMap = await objectAssetService.getAssetsForObjectsArtworks(
+  const artworkAssetsMap = await objectAssetService.getAssetsForArtworks(
     searchResponse.hits.hits
   );
 

--- a/server/app.js
+++ b/server/app.js
@@ -178,7 +178,7 @@ app.use("/api/search", async (req, res) => {
 
   // In case we want to disable interaction with NetX for now
   if (NETX_ENABLED === false) {
-    return searchResponse;
+    return res.json(searchResponse);
   }
 
   // Get information from the DAMS and store it into the response

--- a/server/app.js
+++ b/server/app.js
@@ -604,16 +604,6 @@ app.get("/api/advancedSearchSuggest", craftService.getAutoSuggestions);
 app.get("/api/tour/:slug", tourService.getTour);
 app.get("/api/eye-spy/:id", tourService.getTour);
 
-/** Endpoint for retrieving asset information from the NetX DAMS */
-app.get("/api/objects/:id/assets", async (request, response) => {
-  // The object number needs to go from a schema of "01.02.09" to "01_02_09"
-  // to conform with the DAMS naming schema for rendition names
-  const objectNumber = transformInvno(request.params.id);
-  const result = await objectAssetService.getAssetByObjectNumber(objectNumber);
-
-  response.json(result);
-});
-
 app.use(function (req, res) {
   res.status(404).send("Error 404: Page not Found");
 });

--- a/server/app.js
+++ b/server/app.js
@@ -181,15 +181,10 @@ app.use("/api/search", async (req, res) => {
     return searchResponse;
   }
 
-  const artworkAssetsMap = await objectAssetService.getAssetsForArtworks(
+  // Get information from the DAMS and store it into the response
+  searchResponse.hits.hits = await objectAssetService.getAssetsForArtworks(
     searchResponse.hits.hits
   );
-
-  // We'll store renditions into the `__source` field
-  searchResponse.hits.hits = searchResponse.hits.hits.map((artwork) => {
-    artwork._source["renditions"] = artworkAssetsMap[artwork._source.id] || [];
-    return artwork;
-  });
 
   return res.json(searchResponse);
 });

--- a/server/app.js
+++ b/server/app.js
@@ -38,7 +38,7 @@ const buildSearchAssets = require("../scripts/build-search-assets");
 const craftService = require("./services/craftService");
 const tourService = require("./services/tourService");
 const elasticSearchService = require("./services/elasticSearchService");
-const damsService = require("./services/damsService");
+const objectAssetService = require("./services/objectAssetService");
 const {
   BARNES_SETTINGS,
   ALL_MORE_LIKE_THIS_FIELDS,
@@ -579,7 +579,7 @@ app.get("/api/objects/:id/assets", async (request, response) => {
   // The object number needs to go from a schema of "01.02.09" to "01_02_09"
   // to conform with the DAMS naming schema for rendition names
   const objectNumber = request.params.id.replace(/\./g, "_");
-  const result = await damsService.getAssetByObjectNumber(objectNumber);
+  const result = await objectAssetService.getAssetByObjectNumber(objectNumber);
 
   response.json(result);
 });

--- a/server/app.js
+++ b/server/app.js
@@ -17,6 +17,7 @@ const googleUA = require("universal-analytics");
 const htpasswdFilePath = path.resolve(__dirname, "../.htpasswd");
 const { ui, meta } = require("../src/shared/config");
 const { generateObjectImageUrls } = require("../src/shared/utils");
+const { transformInvno } = require("./utils/transformInvno");
 
 // using this instead of ejs to template from the express routes after we fetch object data.
 // because the webpack compiler is already using ejs.
@@ -607,7 +608,7 @@ app.get("/api/eye-spy/:id", tourService.getTour);
 app.get("/api/objects/:id/assets", async (request, response) => {
   // The object number needs to go from a schema of "01.02.09" to "01_02_09"
   // to conform with the DAMS naming schema for rendition names
-  const objectNumber = request.params.id.replace(/\./g, "_");
+  const objectNumber = transformInvno(request.params.id);
   const result = await objectAssetService.getAssetByObjectNumber(objectNumber);
 
   response.json(result);

--- a/server/constants/times.js
+++ b/server/constants/times.js
@@ -1,6 +1,8 @@
 const oneSecond = 1000;
 const oneDay = 60 * 60 * 24 * oneSecond;
+const oneWeek = 7 * oneDay;
 
 module.exports = {
   oneDay,
+  oneWeek,
 };

--- a/server/services/craftService.js
+++ b/server/services/craftService.js
@@ -113,7 +113,7 @@ const getAutoSuggestions = async (request, response) => {
 };
 
 /** Stores the entries from Craft in a cache */
-const entryCacher = async (request, response) => {
+const entryCacher = async (_, response) => {
   const key = `__cache__api_craft__entries`;
   const body = memoryCache.get(key);
 

--- a/server/services/damsService/damsService.js
+++ b/server/services/damsService/damsService.js
@@ -11,6 +11,7 @@ const {
 const {
   generateGetAssetsByQuery: generateGetAssetsBySearchQuery,
 } = require("./generateAssetQuery");
+const { transformInvno } = require("../../utils/transformInvno");
 
 const NETX_API_TOKEN = process.env.NETX_API_TOKEN;
 const NETX_BASE_URL = process.env.REACT_APP_NETX_BASE_URL;
@@ -37,11 +38,15 @@ async function makeNetXRequest(query) {
   return response;
 }
 
-async function getAssetByObjectNumber(objectNumber) {
+async function getAssetByObjectNumber(rawObjectNumber) {
   // In case we want to disable interaction with NetX for now
   if (NETX_ENABLED === false) {
     return [];
   }
+
+  // We need to transform the object number because it is formatted
+  // differently in the folder paths in NetX
+  const objectNumber = transformInvno(rawObjectNumber);
 
   // We'll check to see if we there exists a sub-folder
   // for this Object Number at the below folder path

--- a/server/services/damsService/damsService.js
+++ b/server/services/damsService/damsService.js
@@ -8,7 +8,9 @@ const {
 const {
   generateGetAssetsByFolderQuery,
 } = require("./generateGetAssetsByFolderQuery");
-const { generateGetAssetsByQuery } = require("./generateAssetQuery");
+const {
+  generateGetAssetsByQuery: generateGetAssetsBySearchQuery,
+} = require("./generateAssetQuery");
 
 const NETX_API_TOKEN = process.env.NETX_API_TOKEN;
 const NETX_BASE_URL = process.env.REACT_APP_NETX_BASE_URL;
@@ -65,7 +67,7 @@ async function getAssetByObjectNumber(objectNumber) {
 
 async function getAssetsByObjectIds(objectIds) {
   const assetQueryResponse = await makeNetXRequest(
-    generateGetAssetsByQuery(objectIds)
+    generateGetAssetsBySearchQuery(objectIds)
   );
 
   const assets = groupAssets(assetQueryResponse.data.result.results);

--- a/server/services/damsService/damsService.js
+++ b/server/services/damsService/damsService.js
@@ -169,4 +169,5 @@ function getValueFromNetXAttribute(attributeName, asset) {
 module.exports = {
   getAssetByObjectNumber,
   getAssetsByObjectIds,
+  getValueFromAsset: getValueFromNetXAttribute,
 };

--- a/server/services/damsService/damsService.js
+++ b/server/services/damsService/damsService.js
@@ -1,3 +1,6 @@
+/** Service responsible for fetching from the NetX DAMS to retrieve asset information for
+ * artwork and archival objects in the Barnes Collection
+ */
 const axios = require("axios");
 const {
   generateGetFolderByPathQuery,

--- a/server/services/damsService/generateAssetQuery.js
+++ b/server/services/damsService/generateAssetQuery.js
@@ -1,8 +1,12 @@
 const COLLECTION_WEBSITE_API_FOLDER = 646;
 function generateGetAssetsByQuery(objectIdList) {
-  const orObjectIdQueries = objectIdList.map((objectId) => {
+  const objectIdQueries = objectIdList.map((objectId) => {
     return {
-      operator: "or",
+      // If we're only requested one specific Object ID, we're
+      // fine to use the "and" operator for an exact match
+      // Otherwise, we want multiple Object IDs in our request
+      // so we have to use the "or" operator to allow that
+      operator: objectIdList.length === 1 ? "and" : "or",
       exact: {
         attribute: "ObjectID (TMS)",
         value: objectId,
@@ -17,6 +21,7 @@ function generateGetAssetsByQuery(objectIdList) {
     params: [
       {
         query: [
+          ...objectIdQueries,
           // Query statement is to scope the search within our "Collection Website API" folder in NetX
           {
             operator: "and",
@@ -25,7 +30,6 @@ function generateGetAssetsByQuery(objectIdList) {
               recursive: true,
             },
           },
-          ...orObjectIdQueries,
         ],
       },
       {
@@ -43,6 +47,7 @@ function generateGetAssetsByQuery(objectIdList) {
           "asset.attributes",
           "asset.file",
           "asset.proxies",
+          "asset.folders",
         ],
       },
     ],

--- a/server/services/damsService/generateAssetQuery.js
+++ b/server/services/damsService/generateAssetQuery.js
@@ -1,7 +1,18 @@
-function generateGetAssetQuery(objectId) {
+const COLLECTION_WEBSITE_API_FOLDER = 646;
+function generateGetAssetsByQuery(objectIdList) {
+  const orObjectIdQueries = objectIdList.map((objectId) => {
+    return {
+      operator: "or",
+      exact: {
+        attribute: "ObjectID (TMS)",
+        value: objectId,
+      },
+    };
+  });
+
   return {
     jsonrpc: "2.0",
-    id: `GET_ASSETS_BY_QUERY_${objectId}`,
+    id: `GET_ASSETS_BY_QUERY_OBJECT_IDS${Date.now()}`,
     method: "getAssetsByQuery",
     params: [
       {
@@ -10,17 +21,11 @@ function generateGetAssetQuery(objectId) {
           {
             operator: "and",
             folder: {
-              folderId: 646,
-              recursive: false,
+              folderId: COLLECTION_WEBSITE_API_FOLDER,
+              recursive: true,
             },
           },
-          {
-            operator: "and",
-            exact: {
-              attribute: "ObjectID (TMS)",
-              value: objectId,
-            },
-          },
+          ...orObjectIdQueries,
         ],
       },
       {
@@ -30,7 +35,7 @@ function generateGetAssetQuery(objectId) {
         },
         page: {
           startIndex: 0,
-          size: 10,
+          size: 200,
         },
         data: [
           "asset.id",
@@ -45,5 +50,5 @@ function generateGetAssetQuery(objectId) {
 }
 
 module.exports = {
-  generateGetAssetQuery,
+  generateGetAssetsByQuery,
 };

--- a/server/services/damsService/generateAssetQuery.js
+++ b/server/services/damsService/generateAssetQuery.js
@@ -21,13 +21,35 @@ function generateGetAssetsByQuery(objectIdList) {
     params: [
       {
         query: [
-          ...objectIdQueries,
           // Query statement is to scope the search within our "Collection Website API" folder in NetX
           {
             operator: "and",
             folder: {
               folderId: COLLECTION_WEBSITE_API_FOLDER,
               recursive: true,
+            },
+          },
+          // We only want primary images
+          {
+            operator: "and",
+            exact: {
+              attribute: "Primary Display Image (TMS)",
+              value: "Primary Display Image",
+            },
+          },
+          // We only want jpgs
+          {
+            operator: "and",
+            exact: {
+              field: "fileType",
+              value: "jpg",
+            },
+          },
+          // Subquery to only get the Object IDs we want
+          {
+            operator: "and",
+            subquery: {
+              query: objectIdQueries,
             },
           },
         ],
@@ -39,7 +61,7 @@ function generateGetAssetsByQuery(objectIdList) {
         },
         page: {
           startIndex: 0,
-          size: 200,
+          size: 3000,
         },
         data: [
           "asset.id",

--- a/server/services/damsService/generateGetAssetsByFolderQuery.js
+++ b/server/services/damsService/generateGetAssetsByFolderQuery.js
@@ -12,6 +12,7 @@ function generateGetAssetsByFolderQuery(folderId) {
           "asset.attributes",
           "asset.file",
           "asset.proxies",
+          "asset.views",
         ],
       },
     ],

--- a/server/services/damsService/index.js
+++ b/server/services/damsService/index.js
@@ -1,5 +1,9 @@
-const { getAssetByObjectNumber } = require("./damsService");
+const {
+  getAssetByObjectNumber,
+  getAssetsByObjectIds,
+} = require("./damsService");
 
 module.exports = {
   getAssetByObjectNumber,
+  getAssetsByObjectIds,
 };

--- a/server/services/damsService/index.js
+++ b/server/services/damsService/index.js
@@ -1,9 +1,11 @@
 const {
   getAssetByObjectNumber,
   getAssetsByObjectIds,
+  getValueFromAsset,
 } = require("./damsService");
 
 module.exports = {
   getAssetByObjectNumber,
   getAssetsByObjectIds,
+  getValueFromAsset,
 };

--- a/server/services/elasticSearchService.js
+++ b/server/services/elasticSearchService.js
@@ -11,31 +11,30 @@ const performSearch = async (body) => {
   });
 };
 
-const search = async (req, res) => {
-  // Get the body from a get or post request
-  const body = req.method === "GET" ? req.query.body : req.body.body;
+const search = async (searchQuery) => {
   try {
-    const esRes = await performSearch(body);
-    res.json(esRes);
-  } catch (e) {
-    res.json(e);
+    const searchResponse = await performSearch(searchQuery);
+    return searchResponse;
+  } catch (error) {
+    return error;
   }
 };
 
-const getObjectById = async (req, res) => {
+const getObjectById = async (objectId) => {
   const options = {
     index: esIndex,
     type: "object",
-    id: req.params.object_id,
+    id: objectId,
   };
 
-  esClient.get(options, function (error, esRes) {
-    if (error) {
-      console.error(`[error] esClient: ${error.message}`);
-      res.json(error);
-    } else {
-      res.json(esRes._source);
-    }
+  return await new Promise((resolve) => {
+    esClient.get(options, function (error, esRes) {
+      if (error) {
+        console.error(`[error] esClient: ${error.message}`);
+        return resolve(error);
+      }
+      return resolve(esRes._source);
+    });
   });
 };
 

--- a/server/services/objectAssetService.js
+++ b/server/services/objectAssetService.js
@@ -1,0 +1,36 @@
+/** Service responsible for abstracting out the utilities for retrieving asset information for the Barnes Collection
+ *  and caching the responses to avoid refetching object information that is needed frequently
+ *
+ */
+const damsService = require("./damsService");
+const memoryCache = require("memory-cache");
+const { oneWeek } = require("../constants/times");
+
+const OBJECT_CACHE = "OBJECT_CACHE";
+
+function makeObjectCacheKey(objectNumber) {
+  return `${OBJECT_CACHE}_${objectNumber}`;
+}
+
+async function getAssetByObjectNumber(objectNumber) {
+  const objectCacheKey = makeObjectCacheKey(objectNumber);
+  const objectAsset = memoryCache.get(objectCacheKey);
+
+  // If we don't have a cached version of this object asset
+  // let's fetch it live, store it, then return it
+  if (!objectAsset) {
+    const liveObjectAsset = await damsService.getAssetByObjectNumber(
+      objectNumber
+    );
+    memoryCache.put(objectCacheKey, liveObjectAsset, oneWeek);
+
+    return liveObjectAsset;
+  }
+
+  // Otherwise, we have the cached version
+  return objectAsset;
+}
+
+module.exports = {
+  getAssetByObjectNumber,
+};

--- a/server/services/objectAssetService.js
+++ b/server/services/objectAssetService.js
@@ -65,11 +65,26 @@ async function getAssetsForArtworks(artworks) {
   // Otherwise, we're fetching a single artwork object's renditions
   // so we do need archival renditions as part of our list
   // and need some extra work to do so
-  const { objectNumber, objectId } = artworksInformation[0];
+  const { objectNumber } = artworksInformation[0];
   const artworkAssets = await getAssetByObjectNumber(objectNumber);
 
+  // We store the renditions but also aditional fields needed
+  // for single artwork rendering
   return artworks.map((artwork) => {
-    artwork._source["renditions"] = artworkAssets || [];
+    const renditions = artworkAssets || [];
+    const rendition = renditions[0];
+
+    artwork._source["renditions"] = renditions;
+    artwork._source["publishedProvenance"] = rendition
+      ? damsService.getValueFromAsset("Published Provenance (TMS)", rendition)
+      : "";
+    artwork._source["publishedArchivesReference"] = rendition
+      ? damsService.getValueFromAsset(
+          "Published Archives Reference (TMS)",
+          rendition
+        )
+      : "";
+
     return artwork;
   });
 }

--- a/server/services/objectAssetService.js
+++ b/server/services/objectAssetService.js
@@ -31,6 +31,16 @@ async function getAssetByObjectNumber(objectNumber) {
   return objectAsset;
 }
 
+async function getAssetsForObjectsArtworks(artworks) {
+  const objectIds = artworks.map((result) => {
+    return result._source.id;
+  });
+
+  const objectIdAssets = await damsService.getAssetsByObjectIds(objectIds);
+  return objectIdAssets;
+}
+
 module.exports = {
   getAssetByObjectNumber,
+  getAssetsForObjectsArtworks,
 };

--- a/server/services/objectAssetService.js
+++ b/server/services/objectAssetService.js
@@ -5,7 +5,6 @@
 const damsService = require("./damsService");
 const memoryCache = require("memory-cache");
 const { oneWeek } = require("../constants/times");
-const { transformInvno } = require("../utils/transformInvno");
 
 const OBJECT_CACHE = "OBJECT_CACHE";
 
@@ -40,9 +39,7 @@ async function getAssetsForArtworks(artworks) {
   const artworksInformation = artworks.map((result) => {
     return {
       objectId: result._source.id,
-      objectNumber: result._source.invno
-        ? transformInvno(result._source.invno)
-        : null,
+      objectNumber: result._source.invno ? result._source.invno : null,
     };
   });
 

--- a/server/utils/transformInvno.js
+++ b/server/utils/transformInvno.js
@@ -1,3 +1,6 @@
+/** Replaces the Object Number `.` character with `_`
+ * since that's how the folders named by Object Number are formatted in NetX
+ */
 function transformInvno(objectNumber) {
   return objectNumber.replace(/\./g, "_");
 }

--- a/server/utils/transformInvno.js
+++ b/server/utils/transformInvno.js
@@ -1,0 +1,7 @@
+function transformInvno(objectNumber) {
+  return objectNumber.replace(/\./g, "_");
+}
+
+module.exports = {
+  transformInvno,
+};

--- a/src/actions/objects.js
+++ b/src/actions/objects.js
@@ -16,6 +16,7 @@ import { uniqBy } from "lodash";
 
 const RAW_OPTION = [
   "id",
+  "invno",
   "title",
   "people",
   "medium",

--- a/src/components/ArtObjectGrid/ArtObjectGrid.jsx
+++ b/src/components/ArtObjectGrid/ArtObjectGrid.jsx
@@ -8,7 +8,11 @@ import SpinnerLoader from "./SpinnerLoader";
 import CollectionFiltersApplied from "../CollectionFilters/CollectionFiltersApplied";
 import { clearObject } from "../../actions/object";
 import { getNextObjects } from "../../actions/objects";
-import { getArtObjectUrlFromId, getImageURLFromRendition } from "../../helpers";
+import {
+  NETX_ENABLED,
+  getArtObjectUrlFromId,
+  getImageURLFromRendition,
+} from "../../helpers";
 import ensembleIndexes from "../../ensembleIndexes";
 import { ART_OBJECT_GRID_INCREMENT } from "../../constants";
 import { DROPDOWN_TERMS } from "../SearchInput/Dropdowns/Dropdowns";
@@ -64,7 +68,8 @@ const GridListElement = ({
   let gridListElementClassNames = "masonry-grid-element";
   if (isFilterResult)
     gridListElementClassNames = `${gridListElementClassNames} search-results-grid__element`;
-  const renditions = object.renditions ? object.renditions : null;
+  const renditions =
+    NETX_ENABLED && object.renditions ? object.renditions : null;
   const primaryRendition = renditions?.length ? renditions[0] : null;
 
   const artworkRenditionThumbnailUrl = primaryRendition

--- a/src/components/ArtObjectGrid/ArtObjectGrid.jsx
+++ b/src/components/ArtObjectGrid/ArtObjectGrid.jsx
@@ -8,7 +8,7 @@ import SpinnerLoader from "./SpinnerLoader";
 import CollectionFiltersApplied from "../CollectionFilters/CollectionFiltersApplied";
 import { clearObject } from "../../actions/object";
 import { getNextObjects } from "../../actions/objects";
-import { getArtObjectUrlFromId } from "../../helpers";
+import { getArtObjectUrlFromId, getImageURLFromRendition } from "../../helpers";
 import ensembleIndexes from "../../ensembleIndexes";
 import { ART_OBJECT_GRID_INCREMENT } from "../../constants";
 import { DROPDOWN_TERMS } from "../SearchInput/Dropdowns/Dropdowns";
@@ -64,6 +64,15 @@ const GridListElement = ({
   let gridListElementClassNames = "masonry-grid-element";
   if (isFilterResult)
     gridListElementClassNames = `${gridListElementClassNames} search-results-grid__element`;
+  const renditions = object.renditions ? object.renditions : null;
+  const primaryRendition = renditions?.length ? renditions[0] : null;
+
+  const artworkRenditionThumbnailUrl = primaryRendition
+    ? getImageURLFromRendition(primaryRendition, "Thumbnail")
+    : null;
+  const artworkRenditionPreviewUrl = primaryRendition
+    ? getImageURLFromRendition(primaryRendition, "Preview")
+    : null;
 
   return (
     <li className={gridListElementClassNames}>
@@ -90,8 +99,8 @@ const GridListElement = ({
           title={object.title}
           people={object.people}
           medium={object.medium}
-          imageUrlSmall={object.imageUrlSmall}
-          imageUrlLarge={object.imageUrlLarge}
+          imageUrlSmall={artworkRenditionThumbnailUrl || object.imageUrlSmall}
+          imageUrlLarge={artworkRenditionPreviewUrl || object.imageUrlLarge}
           // Only pass highlight if this is for search results.
           highlight={isSearchResult ? object.highlight : null}
         />

--- a/src/components/ArtObjectPageComponents/PanelDetails/index.jsx
+++ b/src/components/ArtObjectPageComponents/PanelDetails/index.jsx
@@ -22,12 +22,14 @@ const DEFAULT_THUMBNAIL_COUNT = 5;
 const getTabList = (artObjectProps, renditions) => {
   // Get the attributes from the primary rendition
   const artworkAttributes = renditions[0]?.attributes;
-  const publishedProvenance = artworkAttributes
-    ? artworkAttributes["Published Provenance (TMS)"][0]
-    : "";
-  const publishedArchivesReference = artworkAttributes
-    ? artworkAttributes["Published Archives Reference (TMS)"][0]
-    : "";
+  const publishedProvenance =
+    artworkAttributes && artworkAttributes["Published Provenance (TMS)"]
+      ? artworkAttributes["Published Provenance (TMS)"][0]
+      : "";
+  const publishedArchivesReference =
+    artworkAttributes && artworkAttributes["Published Archives Reference (TMS)"]
+      ? artworkAttributes["Published Archives Reference (TMS)"][0]
+      : "";
 
   return [
     {

--- a/src/components/ArtObjectPageComponents/PanelDetails/index.jsx
+++ b/src/components/ArtObjectPageComponents/PanelDetails/index.jsx
@@ -12,11 +12,8 @@ import * as PrintActions from "../../../actions/prints";
 import { getObjectCopyright } from "../../../copyrightMap";
 import { ShareDialog } from "../../ShareDialog/ShareDialog";
 import "./index.css";
-import { ui } from "../../../shared/config";
-import { getImageURLFromRendition } from "../../../helpers";
+import { NETX_ENABLED, getImageURLFromRendition } from "../../../helpers";
 
-const ENABLE_ADDITIONAL_RENDITIONS =
-  process.env.REACT_APP_NETX_ENABLED === "true" ? true : false;
 const DEFAULT_THUMBNAIL_COUNT = 5;
 
 const getTabList = (artObjectProps) => {
@@ -213,7 +210,7 @@ class Image extends Component {
 
     // This indicates that there was an error with rendering the Zoom component
     const { didCatchFailure } = this.state;
-    const renditionsExist = renditions?.length > 0;
+    const renditionsExist = NETX_ENABLED && renditions?.length > 0;
     const showZoomImageView = Boolean(
       !didCatchFailure &&
         object.id &&

--- a/src/components/ArtObjectPageComponents/PanelDetails/index.jsx
+++ b/src/components/ArtObjectPageComponents/PanelDetails/index.jsx
@@ -1,5 +1,4 @@
 import React, { Component } from "react";
-import axios from "axios";
 
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
@@ -14,6 +13,7 @@ import { getObjectCopyright } from "../../../copyrightMap";
 import { ShareDialog } from "../../ShareDialog/ShareDialog";
 import "./index.css";
 import { ui } from "../../../shared/config";
+import { getImageURLFromRendition } from "../../../helpers";
 
 const ENABLE_ADDITIONAL_RENDITIONS =
   process.env.REACT_APP_NETX_ENABLED === "true" ? true : false;
@@ -89,11 +89,7 @@ class Thumbnail extends Component {
     const { isLandscapeThumbnail } = this.state;
     const { onClick, isActive, alt, rendition } = this.props;
 
-    const imageThumbnailProxy = rendition.proxies.find((proxy) => {
-      return proxy.name === "Thumbnail";
-    });
-
-    const imageSourceUrl = `${ui.netxBaseURL}${imageThumbnailProxy.file.url}/`;
+    const imageSourceUrl = getImageURLFromRendition(rendition, "Thumbnail");
     const renditionCaption = getCaptionFromArtworkRendition(rendition);
 
     // Set up classNames, if selected add BEM modifier.
@@ -236,14 +232,11 @@ class Image extends Component {
     }
 
     // We'll render the image from the object renditions itself
-    if (renditionsExist) {
-      // We have to build the image URL from the asset information
-      const imagePreview = renditions[activeImageIndex].proxies.find(
-        (proxy) => {
-          return proxy.name === "Zoom";
-        }
+    if (renditionsExist && renditions[activeImageIndex]) {
+      imageUrlToRender = getImageURLFromRendition(
+        renditions[activeImageIndex],
+        "Zoom"
       );
-      imageUrlToRender = `${ui.netxBaseURL}${imagePreview.file.url}/`;
       captionToRender = getCaptionFromArtworkRendition(
         renditions[activeImageIndex],
         object

--- a/src/components/ArtObjectPageComponents/PanelDetails/index.jsx
+++ b/src/components/ArtObjectPageComponents/PanelDetails/index.jsx
@@ -20,19 +20,6 @@ const ENABLE_ADDITIONAL_RENDITIONS =
 const DEFAULT_THUMBNAIL_COUNT = 5;
 
 const getTabList = (artObjectProps) => {
-  // Get the attributes from the primary rendition
-  const artworkAttributes = artObjectProps?.renditions?.length
-    ? artObjectProps.renditions[0]?.attributes
-    : null;
-  const publishedProvenance =
-    artworkAttributes && artworkAttributes["Published Provenance (TMS)"]
-      ? artworkAttributes["Published Provenance (TMS)"][0]
-      : "";
-  const publishedArchivesReference =
-    artworkAttributes && artworkAttributes["Published Archives Reference (TMS)"]
-      ? artworkAttributes["Published Archives Reference (TMS)"][0]
-      : "";
-
   return [
     {
       title: "Long Description",
@@ -48,11 +35,11 @@ const getTabList = (artObjectProps) => {
     },
     {
       title: "Provenance",
-      tabContent: publishedProvenance,
+      tabContent: artObjectProps.publishedProvenance,
     },
     {
       title: "Archives Reference",
-      tabContent: publishedArchivesReference,
+      tabContent: artObjectProps.publishedArchivesReference,
     },
   ].filter(({ tabContent }) => tabContent);
 }; // Filter out tabs with no content.

--- a/src/components/ArtObjectPageComponents/PanelDetails/index.jsx
+++ b/src/components/ArtObjectPageComponents/PanelDetails/index.jsx
@@ -349,7 +349,11 @@ class PanelDetails extends Component {
   render() {
     const { object, prints } = this.props;
     const { imageLoaded, activeImageIndex, thumbnailsOpen } = this.state;
-    const { renditions } = object;
+
+    // Filter out renditions for now
+    object.renditions = object.renditions?.filter(
+      (rendition) => rendition.fileName.includes(".tif") === false
+    );
 
     const printAvailable = prints.find(({ id }) => id === object.invno);
 
@@ -370,7 +374,7 @@ class PanelDetails extends Component {
             setActiveImageIndex={this.setActiveImageIndex}
           />
           {/** Uncomment this once we have thumbnail data. */}
-          {Boolean(imageLoaded) && renditions?.length ? (
+          {Boolean(imageLoaded) && object.renditions?.length ? (
             <Thumbnails
               activeImageIndex={activeImageIndex}
               setActiveImageIndex={this.setActiveImageIndex}

--- a/src/components/ArtObjectPageComponents/PanelDetails/index.jsx
+++ b/src/components/ArtObjectPageComponents/PanelDetails/index.jsx
@@ -140,13 +140,11 @@ const Thumbnails = ({
   isOpen,
   toggleOpen,
 }) => {
-  const { renditions } = object;
-  const images = renditions.map((rendition, i) => (
+  const images = object.renditions.map((rendition, i) => (
     <Thumbnail
       key={i}
       onClick={() => setActiveImageIndex(i)}
       isActive={activeImageIndex === i}
-      src={object.imageUrlSmall}
       alt={object.title}
       rendition={rendition}
     />
@@ -178,7 +176,7 @@ const Thumbnails = ({
       {/** We only need to render the "View More/View Less" section when we have more
        *  renditions than our default count. At that point, we need to expand the thumbnail row
        */}
-      {renditions?.length > DEFAULT_THUMBNAIL_COUNT ? (
+      {object.renditions?.length > DEFAULT_THUMBNAIL_COUNT ? (
         <div className={panelButtonClassNames}>
           <div className="panel-button__content" onClick={toggleOpen}>
             <div className="panel-button__icon">
@@ -366,7 +364,7 @@ class PanelDetails extends Component {
     const printAvailable = prints.find(({ id }) => id === object.invno);
 
     const objectCopyrightDetails = getObjectCopyright(object);
-    const accordionTabList = getTabList(object, renditions);
+    const accordionTabList = getTabList(object);
 
     const requestImageUrl = `https://barnesfoundation.wufoo.com/forms/barnes-foundation-image-request/def/field22=${object.people}&field21=${object.title}&field20=${object.invno}`;
     const downloadRequestUrl = `https://barnesfoundation.wufoo.com/forms/barnes-foundation-image-use-information/def/field22=${object.people}&field372=${object.title}&field20=${object.invno}&field374=${object.imageUrlForWufoo}`;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,6 +1,7 @@
 import bodybuilder from "bodybuilder";
 import { BARNES_SETTINGS } from "./barnesSettings";
 import { META_TITLE, META_DESCRIPTION } from "./constants";
+import { ui } from "./shared/config";
 
 const slugify = require("slugify");
 
@@ -59,4 +60,17 @@ export const getQueryKeywordUrl = (qval) => {
 
 export const getQueryFilterUrl = (qval) => {
   return getQueryUrl("filter", qval);
+};
+
+/** Gets the URL for rendering the specified image type from the rendition */
+export const getImageURLFromRendition = (rendition, imageType) => {
+  const imageProxy = rendition.proxies.find(
+    (proxy) => proxy.name === imageType
+  );
+
+  if (!imageProxy) {
+    return "";
+  }
+
+  return `${ui.netxBaseURL}${imageProxy.file.url}/`;
 };

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -74,3 +74,9 @@ export const getImageURLFromRendition = (rendition, imageType) => {
 
   return `${ui.netxBaseURL}${imageProxy.file.url}/`;
 };
+
+/** Determines if renditions from NetX should be rendered
+ * TODO - Move to config file
+ */
+export const NETX_ENABLED =
+  process.env.REACT_APP_NETX_ENABLED === "true" ? true : false;


### PR DESCRIPTION
This pull request makes modifications to the Collection Website to load image assets from NetX when available instead of from our S3 image repository.

The response data from NetX is cached for single-object calls because we need some additional calls to retrieve Archival Image renditions. It is cached for 7-days.

For multi-object calls, we don't cache the data since it seems NetX API responds fast enough.

A quick follow-up is to switch over ensemble images and fix Archival Image rendition loading since there are some permission issues to resolve still.
 