### PR TITLE
IT-21916-handle-room-8-issue

### DIFF
--- a/server/services/damsService/damsService.js
+++ b/server/services/damsService/damsService.js
@@ -44,6 +44,11 @@ async function getAssetByObjectNumber(rawObjectNumber) {
     return [];
   }
 
+  // Handle some edge-case where the object number is not valid
+  if (!rawObjectNumber) {
+    return [];
+  }
+
   // We need to transform the object number because it is formatted
   // differently in the folder paths in NetX
   const objectNumber = transformInvno(rawObjectNumber);


### PR DESCRIPTION
https://barnessupport.atlassian.net/browse/IT-21916

I couldn't reproduce this locally - but I saw that there's an error in the logs where the object number being provided to `transformInvno` is null or undefined.

I'm handling this case now and tentatively this should solve it. It's unexpected that an object number doesn't exist but I have seen this be the case for at least 1 item.