### PR TITLE
IT-21916-additional-logging

### DIFF
--- a/server/services/damsService/damsService.js
+++ b/server/services/damsService/damsService.js
@@ -80,8 +80,19 @@ async function getAssetsByObjectIds(objectIds) {
     generateGetAssetsBySearchQuery(objectIds)
   );
 
-  const assets = groupAssets(assetQueryResponse.data.result.results);
-  return assets;
+  try {
+    const assets = groupAssets(assetQueryResponse.data.result.results);
+    return assets;
+  } catch (error) {
+    console.error(
+      `[DAMSService][getAssetsByObjectIds] Failed with grouping assets
+      assetQueryResponse: ${JSON.stringify(assetQueryResponse)}
+      objectIds: ${JSON.stringify(objectIds)}
+      `,
+      error
+    );
+    return {};
+  }
 }
 
 function sortAssets(assets) {

--- a/server/services/damsService/damsService.js
+++ b/server/services/damsService/damsService.js
@@ -86,7 +86,7 @@ async function getAssetsByObjectIds(objectIds) {
   } catch (error) {
     console.error(
       `[DAMSService][getAssetsByObjectIds] Failed with grouping assets
-      assetQueryResponse: ${JSON.stringify(assetQueryResponse)}
+      assetQueryResponse: ${JSON.stringify(assetQueryResponse.data)}
       objectIds: ${JSON.stringify(objectIds)}
       `,
       error

--- a/server/services/damsService/damsService.js
+++ b/server/services/damsService/damsService.js
@@ -12,6 +12,7 @@ const {
   generateGetAssetsByQuery: generateGetAssetsBySearchQuery,
 } = require("./generateAssetQuery");
 const { transformInvno } = require("../../utils/transformInvno");
+const { splitArray } = require("../../utils/splitArray");
 
 const NETX_API_TOKEN = process.env.NETX_API_TOKEN;
 const NETX_BASE_URL = process.env.REACT_APP_NETX_BASE_URL;
@@ -76,23 +77,40 @@ async function getAssetByObjectNumber(rawObjectNumber) {
 }
 
 async function getAssetsByObjectIds(objectIds) {
-  const assetQueryResponse = await makeNetXRequest(
-    generateGetAssetsBySearchQuery(objectIds)
-  );
+  /** Inner function for allowing for chunking of the requests
+   * to NetX for fetching assets by search query - since it currently
+   * seems like anything more than 100 object ids requested in a single
+   * query causes NetX to error out
+   */
+  async function getAssetsByObjectIdsInner(objectIdChunk) {
+    try {
+      const assetQueryResponse = await makeNetXRequest(
+        generateGetAssetsBySearchQuery(objectIdChunk)
+      );
 
-  try {
-    const assets = groupAssets(assetQueryResponse.data.result.results);
-    return assets;
-  } catch (error) {
-    console.error(
-      `[DAMSService][getAssetsByObjectIds] Failed with grouping assets
-      assetQueryResponse: ${JSON.stringify(assetQueryResponse.data)}
+      return assetQueryResponse.data.result.results;
+    } catch (error) {
+      console.error(
+        `[DAMSService][getAssetsByObjectIdsInner] Failed getting assets by search query
       objectIds: ${JSON.stringify(objectIds)}
       `,
-      error
-    );
-    return {};
+        error
+      );
+
+      return [];
+    }
   }
+
+  // Split the object ids list into lists of 100 and process those chunks
+  const objectIdChunks = splitArray(objectIds, 100);
+  const assetPromises = objectIdChunks.map((chunk) =>
+    getAssetsByObjectIdsInner(chunk)
+  );
+
+  // Group all these assets but from a flat list
+  const assetResults = await Promise.all(assetPromises);
+  const assets = groupAssets(assetResults.flat());
+  return assets;
 }
 
 function sortAssets(assets) {

--- a/server/utils/splitArray.js
+++ b/server/utils/splitArray.js
@@ -1,0 +1,17 @@
+/** Split a given array if `GenericObject` type into an array containing
+ * several arrays of the specified size
+ */
+function splitArray(array, size) {
+  const arrayCollector = [];
+  const arraySize = array.length;
+
+  for (let i = 0; i < arraySize; i += size) {
+    arrayCollector.push(array.slice(i, i + size));
+  }
+
+  return arrayCollector;
+}
+
+module.exports = {
+  splitArray,
+};


### PR DESCRIPTION
https://barnessupport.atlassian.net/browse/IT-21916

Fixes the issue with "Room 8" filtering failing on the Collection Site. This could also be reproduced by requesting multiple rooms in a single call.

The underlying cause was the call to NetX failing when we're requesting artwork images from NetX - during the call to `getAssetsByObjectId` in the DAMSService file.

NetX was failing when more than 100 objects were being requested in a single query. I don't see a limitation in their API documentation, but I was able to work around it by chunking the object requests into requests of 100 objects each.

