### PR TITLE
temporarily-turn-off-archives

### DIFF
--- a/server/services/damsService/damsService.js
+++ b/server/services/damsService/damsService.js
@@ -144,7 +144,8 @@ function sortAssets(assets) {
 
       // It's an archive
       if (syncTypeValue === ARCHIVE_SYNC_TYPE_VALUE) {
-        acc.archives.push(asset);
+        // TODO - Remove the below commentation once we fix archive image rendering
+        // acc.archives.push(asset);
         return acc;
       }
 


### PR DESCRIPTION
Temporarily don't store archive images from NetX into our renditions list sent to the Collection Site frontend. Right now, they're broken because of a permissions problem we're still fixing - so this prevent those broken image links from showing on the site.