### PR TITLE
fix-collection-site-ensemble-image-break

### DIFF
--- a/server/services/damsService/damsService.js
+++ b/server/services/damsService/damsService.js
@@ -122,8 +122,9 @@ async function getEnsembleImageUrl(ensembleIndex) {
   const searchQueryResponse = await makeNetXRequest(fileNameQuery);
 
   // Our query ended up with empty results - so no ensemble image url is possible
-  const results = searchQueryResponse.data.result.results;
-  if (!results.length) {
+  const results =
+    searchQueryResponse.data.result && searchQueryResponse.data.result.results;
+  if (!results || !results.length) {
     return null;
   }
 

--- a/server/services/damsService/queries.js
+++ b/server/services/damsService/queries.js
@@ -134,7 +134,7 @@ function generateGetAssetsByFileNameQuery(ensembleIndex) {
           {
             operator: "and",
             exact: {
-              attribute: "API Ensemble Index",
+              attribute: "API Ensemble Index (TMS)",
               value: ensembleIndex,
             },
           },


### PR DESCRIPTION
The attribute name in NetX for the Ensemble Index value has changed and it caused a break when we query NetX for it.

It used to be `API Ensemble Index` but is now `API Ensemble Index (TMS)`. This pull request modifies that to be correct and adds a null check when parsing the ensemble image response.